### PR TITLE
Make links more visible

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -67,3 +67,6 @@ div[role="main"] blockquote a:hover {
 
 /* We have to preset the div with left 0 for the animation to work */
 .wy-nav-content-wrap { left: 0%; }
+
+/* Links are hard to identify in paragraphs, so we underline them */
+.section a { text-decoration: underline; }

--- a/assets/app.css
+++ b/assets/app.css
@@ -3,6 +3,11 @@
 /*
  * General branding: Let's use the Zettlr green instead of the default blue
  */
+
+.section a { 
+  text-decoration: underline; 
+  color: #404040;
+}
 section.wy-nav-content-wrap a { color: black;}/*rgb(28, 178, 126); }*/
 nav.wy-nav-top a, nav.my-nav-top a:active { color: white; }
 .wy-side-nav-search a, .wy-side-nav-search a:visited { color: white; }
@@ -67,6 +72,3 @@ div[role="main"] blockquote a:hover {
 
 /* We have to preset the div with left 0 for the animation to work */
 .wy-nav-content-wrap { left: 0%; }
-
-/* Links are hard to identify in paragraphs, so we underline them */
-.section a { text-decoration: underline; }


### PR DESCRIPTION
It's really hard to identify links in paragraphs, because the default css styling is overwritten and the underline is removed. 

By adding the `text-decoration: underline` the usability of the docs can be significantly improved in a very simple way.