### PR TITLE
Described what buttons to use for a Zettelkasten

### DIFF
--- a/docs/en/guides/guide-zettelkasten.md
+++ b/docs/en/guides/guide-zettelkasten.md
@@ -32,7 +32,7 @@ To add a new directory to Zettlr, hit `Cmd/Ctrl+O`, click the first toolbar butt
 
 Now you'll be set to use Zettlr as your Zettelkasten management system. Two operations are important in a Zettelkasten:
 
-1. Creating an identifier to a note, so that you can link to it: You can do this by pressing `Ctrl + L` while editing any note, which will paste a generated ID to your note.
+1. Creating an identifier to a note, so that you can link to it: You can do this by pressing `Cmd/Ctrl+L` while editing any note, which will paste a generated ID to your note.
 2. Linking to other notes: Pressing `[[` while editing will display a list of notes you can link to (those who have an idenfitier in them).
 
 If you want to dig deeper into how a Zettelkasten should work and what it should look like, consult the immense amount of resources on Zettelkästen, available on the web. A good starting point is [Zettelkasten.de](https://www.zettelkasten.de/). The authors have assembled a large list of (english) blog posts on how to supercharge your writing using a Zettelkasten.

--- a/docs/en/guides/guide-zettelkasten.md
+++ b/docs/en/guides/guide-zettelkasten.md
@@ -30,4 +30,9 @@ To add a new directory to Zettlr, hit `Cmd/Ctrl+O`, click the first toolbar butt
 
 ## Step 3: Write!
 
-Now you'll be set to use Zettlr as your Zettelkasten management system. If you want to dig deeper into how a Zettelkasten should work and what it should look like, consult the immense amount of resources on Zettelkästen, available on the web. A good starting point is [Zettelkasten.de](https://www.zettelkasten.de/). The authors have assembled a large list of (english) blog posts on how to supercharge your writing using a Zettelkasten.
+Now you'll be set to use Zettlr as your Zettelkasten management system. Two operations are important in a Zettelkasten:
+
+1. Creating an identifier to a note, so that you can link to it: You can do this by pressing `Ctrl + L` while editing any note, which will paste a generated ID to your note.
+2. Linking to other notes: Pressing `[[` while editing will display a list of notes you can link to (those who have an idenfitier in them).
+
+If you want to dig deeper into how a Zettelkasten should work and what it should look like, consult the immense amount of resources on Zettelkästen, available on the web. A good starting point is [Zettelkasten.de](https://www.zettelkasten.de/). The authors have assembled a large list of (english) blog posts on how to supercharge your writing using a Zettelkasten.

--- a/docs/en/guides/guide-zettelkasten.md
+++ b/docs/en/guides/guide-zettelkasten.md
@@ -33,6 +33,6 @@ To add a new directory to Zettlr, hit `Cmd/Ctrl+O`, click the first toolbar butt
 Now you'll be set to use Zettlr as your Zettelkasten management system. Two operations are important in a Zettelkasten:
 
 1. Creating an identifier to a note, so that you can link to it: You can do this by pressing `Cmd/Ctrl+L` while editing any note, which will paste a generated ID to your note.
-2. Linking to other notes: Pressing `[[` while editing will display a list of notes you can link to (those who have an idenfitier in them).
+2. Linking to other notes: Insert the link opening (default: `[[`) while editing to display the auto-complete dropdown, from which you can choose a note to link to.
 
 If you want to dig deeper into how a Zettelkasten should work and what it should look like, consult the immense amount of resources on Zettelkästen, available on the web. A good starting point is [Zettelkasten.de](https://www.zettelkasten.de/). The authors have assembled a large list of (english) blog posts on how to supercharge your writing using a Zettelkasten.


### PR DESCRIPTION
It took me a while to realize that the "identifiers" described were inside the file and not the generated file names, and that I can name my notes however I want. It also took me quite a while to find the `Ctrl + L` shortcut, since it's not described in the Zettelkasten article. Since I assumed people would want this information to be in this article, I added them.