### PR TITLE
fix custom css font change in editor example

### DIFF
--- a/docs/de/core/custom-css.md
+++ b/docs/de/core/custom-css.md
@@ -37,7 +37,7 @@ The placeholder will make sure that even if your font cannot be found, an equiva
 Zettlr already ships a serif font, a sans-serif font and a monospace font! To use the bundled fonts, you can use `Crimson` for a modern serif font or `Liberation Mono` for a nice looking monospace font. (Lato is the default, so you probably don't want to put it there.)
 
 ```css
-#editor {
+#editor * {
     font-family: '<your-font-name here>', <placeholder>;
 }
 ```

--- a/docs/en/core/custom-css.md
+++ b/docs/en/core/custom-css.md
@@ -37,7 +37,7 @@ The placeholder will make sure that even if your font cannot be found, an equiva
 Zettlr already ships a serif font, a sans-serif font and a monospace font! To use the bundled fonts, you can use `Crimson` for a modern serif font or `Liberation Mono` for a nice looking monospace font. (Lato is the default, so you probably don't want to put it there.)
 
 ```css
-#editor {
+#editor * {
     font-family: '<your-font-name here>', <placeholder>;
 }
 ```

--- a/docs/ja/core/custom-css.md
+++ b/docs/ja/core/custom-css.md
@@ -37,7 +37,7 @@ placeholderは、設定したフォントが見つからない場合に、同等
 Zettlrには、セリフ体フォント、サンセリフ体フォント、等幅フォントが同梱されています。現代的なセリフ体フォントの`Crimson`、もしくは美しい等幅フォントの`Liberation Mono`を使うことができます。(デフォルトは`Lato`ですが、これを指定することはないでしょう。)
 
 ```css
-#editor {
+#editor * {
     font-family: '<your-font-name here>', <placeholder>;
 }
 ```


### PR DESCRIPTION
I noticed the star was needed to actually change the font in my Zettlr 1.6.0
I have no experience with CSS, so no idea whether or not it is the right thing to do.