### PR TITLE
[fr] Translation + proofreading top-level docs contents

### DIFF
--- a/docs/fr/5-minutes.md
+++ b/docs/fr/5-minutes.md
@@ -1,10 +1,10 @@
-# Zettlr en 5 Minutes
+# Zettlr en 5 minutes
 
 Bon, vous avez téléchargé et installé l'application, vous avez réglé la minuterie et vous êtes prêt à commencer ? Alors, appuyez sur le bouton du compte à rebours et c'est parti !
 
 ## 1. Ouvrir des répertoires et des fichiers
 
-Pour ouvrir des répertoires ou des fichiers, il suffit de les faire glisser n'importe où sur la fenêtre de l'application. Ils s'ouvriront automatiquement. Vous pouvez également utiliser le raccourci `Cmd/Ctrl+O` pour ouvrir la fenêtre de dialogue de sélection du répertoire.
+Pour ouvrir des répertoires ou des fichiers, il suffit de les faire glisser de n'importe où sur la fenêtre de l'application. Ils s'ouvriront automatiquement. Vous pouvez également utiliser le raccourci `Cmd/Ctrl+O` pour ouvrir la fenêtre de dialogue de sélection du répertoire.
 
 ![open.png](img/open.png)
 
@@ -30,32 +30,32 @@ L'écriture c'est votre job, mais voici les raccourcis les plus importants à re
 
 ![markdown.png](img/markdown.png)
 
-Des choses sans raccourcis, mais aussi importantes :
+Des choses qui ne sont pas des raccourcis, mais qui sont tout aussi importantes :
 
-- Utiliser le signe `#`pour créer des titres. Le nombre de symboles `#`correspond au niveau de titre. Le maximum est 6.
-- Utiliser le signe `>`pour créer des blocs de citations. Vous pouvez également les emboîter en utilisant plusieurs signes supérieurs (par exemple `> >`).
-- Utiliser  le signe`#` _non_ suivi d'un espace pour créer des étiquettes. Vous pouvez utiliser ces étiquettes pour la recherche et la navigation.
+- Utiliser le signe `#` pour créer des titres. Le nombre de symboles `#` correspond au niveau de titre. Le maximum est 6.
+- Utiliser le signe `>` pour créer des blocs de citations. Vous pouvez également les emboîter en utilisant plusieurs fois le signe `>` (par exemple `> >`).
+- Utiliser le signe`#` _non_ suivi d'un espace pour créer des étiquettes (*tags*). Vous pouvez utiliser ces étiquettes pour la recherche et la navigation.
 
 ## 4. Quoi d'autre ?
 
-Si vous utilisez le mode "thin sidebar" (par défaut), vous verrez soit la liste des fichiers, soit l'arborescence des répertoires. Déplacez la souris dans le coin supérieur gauche de la liste de fichiers et cliquez sur la flèche pour afficher l'arborescence des répertoires. Pour basculer entre la liste de fichiers et l'arborescence des répertoires, vous pouvez également cliquer sur `Cmd/Ctrl+!`. Choisissez le mode de la barre latérale étendue dans les préférences pour que la liste des fichiers et l'arborescence des répertoires soient visibles en même temps.
+Si vous utilisez le mode "étroit" de la barre latérale (par défaut), vous verrez soit la liste des fichiers, soit l'arborescence des répertoires. Déplacez la souris dans le coin supérieur gauche de la liste de fichiers et cliquez sur la flèche pour afficher l'arborescence des répertoires. Pour basculer entre la liste de fichiers et l'arborescence des répertoires, vous pouvez également cliquer sur `Cmd/Ctrl+!`. Choisissez le mode de la barre latérale étendue dans les préférences pour que la liste des fichiers et l'arborescence des répertoires soient visibles en même temps.
 
 ![back.png](img/back.png)
 
-Zettlr est strictement basé sur le contexte. Sauf indication contraire, les nouveaux fichiers et répertoires seront créés à l'intérieur du répertoire actuellement sélectionné. Les opérations basées sur les fichiers (renommage ou suppression) viseront par défaut le fichier actuel. Utilisez le menu contextuel en cliquant sur n'importe quel fichier ou répertoire avec le bouton droit de la souris pour sélectionner des fichiers/répertoires spécifiques.
+Zettlr se base strictement sur le contexte. Sauf indication contraire, les nouveaux fichiers et répertoires seront créés à l'intérieur du répertoire actuellement sélectionné. Les opérations basées sur les fichiers (renommage ou suppression) viseront par défaut le fichier actuel. Utilisez le menu contextuel avec un clic droit sur n'importe quel fichier ou répertoire pour le sélectionner et le modifier spécifiquement.
 
 Trois règles simples :
 
-1. La touche `Alt`(ernative) déclenche des actions alternatives sur le même élément.
-2. Le modificateur de touche `Shift` _shifts_ (déplace ?) la cible d'une action vers un autre élément (le plus souvent le répertoire au lieu du fichier).
+1. La touche `Alt` déclenche des actions *alternatives* sur le même élément.
+2. Le modificateur de touche `Maj` déplace la cible d'une action vers un autre élément (le plus souvent le répertoire au lieu du fichier).
 3. Toutes les actions cruciales se trouvent dans la barre d'outils. À gauche se trouvent les actions générales, au milieu les actions basées sur des fichiers et à droite les autres actions.
 
-## 5. Bien, j'ai fini d'écrire. Comment puis-je le partager (exporter) ?
+## 5. Bien, j'ai fini d'écrire. Comment puis-je partager (exporter) mon texte ?
 
-Trois étapes faciles :
+En trois étapes :
 
-1. Assurez-vous que Pandoc et LaTeX (uniquement nécessaire pour les PDF) sont installés.
-2. Cliquez sur le bouton de partage dans la barre d'outils (ou appuyez sur `Cmd/Ctrl+E`) et sélectionnez le format cible. L'ouverture révèle les présentations (elles sont faites à l'aide de reveal.js - vous comprenez le jeu de mots -_pun_- ?)
+1. Assurez-vous que Pandoc soit installé, ainsi que LaTeX (ce dernier est nécessaire seulement pour les PDF).
+2. Cliquez sur le bouton de partage dans la barre d'outils (ou appuyez sur `Cmd/Ctrl+E`) et sélectionnez le format cible. Le logo en forme d'ouverture révèle les présentations (elles sont faites à l'aide de reveal.js – vous l'avez ?)
 3. Lors de l'exportation, Zettlr ouvre automatiquement le fichier exporté dans votre application préférée. Dans cette application, appuyez sur `Cmd/Ctrl+Shift+S` (devrait fonctionner dans la plupart des applications) pour le sauvegarder où vous voulez.
 
 ![export.png](img/export.png)
@@ -64,6 +64,6 @@ Trois étapes faciles :
 
 Non, vous pouvez y aller. Si vous voulez approfondir le sujet, n'oubliez pas de consulter nos guides :
 
-- [Zettlr as a note-taking app](guides/guide-notes.md)
-- [Zettlr as a Zettelkasten](guides/guide-zettelkasten.md)
-- [Zettlr as an IDE](guides/guide-ide.md)
+* [Utiliser Zettlr comme application de prise de notes](guides/guide-notes.md)
+* [Utiliser Zettlr comme Zettelkasten](guides/guide-zettelkasten.md)
+* [Utiliser Zettlr comme environnement de développement intégré (IDE)](guides/guide-ide.md)

--- a/docs/fr/faq.md
+++ b/docs/fr/faq.md
@@ -1,134 +1,137 @@
-# Frequently Asked Questions
+# Foire aux questions
 
 ## J'ai essayé d'installer Zettlr sur Windows, mais il y a un avertissement de sécurité disant que je ne dois pas installer l'application !
 
 Windows et MacOS exigent tous deux une "signature de code" afin de pouvoir faire confiance à l'application. Bien qu'il s'agisse d'une excellente technique pour empêcher les codes malveillants de nuire à votre système, elle nécessite un certificat de signature de code. Bien que nos versions de macOS soient déjà signées, nous sommes encore en train de demander un certificat de signature de code pour Windows. D'ici là, vous pouvez ignorer ces avertissements et installer Zettlr, à condition de le télécharger depuis notre page officielle.
 
-## Est-il prévu de porter Zettlr sur les téléphones mobiles et les tables, pour Android ou iOS ?
+## Est-il prévu de porter Zettlr sur les téléphones mobiles et les tablettes, pour Android ou iOS ?
 
-Nous recevons de plus en plus de demandes pour des versions mobiles de Zettlr. Nous sommes très heureux que vous aimiez suffisamment Zettlr pour le vouloir sur tous vos appareils, et nous aimerions réaliser votre souhait ! Malheureusement, nos ressources sont tout juste suffisantes pour maintenir le développement de Zettlr en marche, et il n'est pas possible d'ajouter du travail pour le moment.
+Nous recevons de plus en plus de demandes pour des versions mobile de Zettlr. Nous sommes très heureux que vous aimiez suffisamment Zettlr pour le vouloir sur tous vos appareils, et nous aimerions réaliser ce souhait ! Malheureusement, nos ressources sont tout juste suffisantes pour maintenir le développement de l'application sur ordinateur, et il n'est pas possible de fournir plus de travail pour le moment.
 
-## What is Markdown?
+## Qu'est-ce que Markdown ?
 
-Markdown is a simple markup language that enables you to write text just as complex as using standard office software, but with much less clutter. Instead of having to manually select all formatting options, in Markdown, typing a `#` suffices to indicate a heading! Want to hear more? Then head over to the [documentation on Markdown](reference/markdown-basics.md)!
+Markdown est un langage de balisage léger qui vous permet de rédiger un texte aussi complexe qu'un logiciel de bureautique standard, mais avec beaucoup moins d'encombrement. Au lieu de devoir sélectionner manuellement toutes les options de formatage, dans Markdown, il suffit de taper un `#` pour indiquer un titre ! Vous voulez en savoir plus ? Consultez notre [documentation sur les bases de Markdown](reference/markdown-basics.md) !
 
 ## Si je ne veux plus utiliser Zettlr, que dois-je faire pour changer de programme ?
 
-Il suffit de désinstaller Zettlr et de commencer à utiliser un autre programme de votre choix. Zettlr ne touche pas à vos fichiers. Si vous avez utilisé Virtual Directories ou Projects, il y aura de petits fichiers nommés `.ztr-directory` présents dans certains dossiers. Pour les supprimer, il suffit de supprimer tout répertoire virtuel, de réinitialiser le tri des répertoires par défaut et de supprimer tous les projets avant de désinstaller l'application (ou de supprimer manuellement ces fichiers par la suite).
-## Parfois, je ne veux pas d'AutoCorrect - comment puis-je faire en sorte qu'il cesse de s'autocorriger dans un cas précis ?
+Il suffit de désinstaller Zettlr et de commencer à utiliser un autre programme de votre choix. Zettlr ne touche pas à vos fichiers. Si vous avez utilisé les Dossiers virtuels ou les Projets, il y aura de petits fichiers nommés `.ztr-directory` présents dans certains dossiers. Pour les supprimer, il suffit de supprimer tout répertoire virtuel, de réinitialiser le tri des répertoires par défaut et de supprimer tous les projets avant de désinstaller l'application (ou de supprimer manuellement ces fichiers par la suite).
 
-Bien qu'AutoCorrect soit un excellent outil, il y a ces quelques cas où nous ne voulons pas qu'il s'applique. Un exemple souvent cité est le YAML-frontmatter. Si vous écrivez les trois derniers points ou tirets, l'AutoCorrect de Zettlr les transforme en ellipse ou en tiret, selon les caractères utilisés. Zettlr analysera alors l'ensemble du fichier en tant que YAML, et non en tant que Markdown. Afin d'empêcher l'application de l'AutoCorrect de Zettlr, voici comment procéder :
+## Parfois, je ne veux pas d'AutoCorrect - comment puis-je faire en sorte qu'il cesse d'autocorriger dans un cas précis ?
 
-1. Si vous utilisez l'AutoCorrection de type LibreOffice, il suffit de maintenir la touche Maj enfoncée tout en appuyant sur Espace ou Retour (l'AutoCorrection ne s'applique que sur Espace ou Retour). Cela incitera Zettlr à ne pas "corriger" automatiquement dans ce cas.
-2. Si vous utilisez la correction automatique de mots, appuyez simplement sur la touche Retour arrière dès que vous avez tapé un espace après l'application de la correction automatique. Cela annulera l'autocorrection et restaurera les caractères originaux.
+Bien qu'AutoCorrect soit un excellent outil, il peut y avoir quelques cas où nous ne voulons pas qu'il s'applique. Un exemple souvent cité est le bloc de métadonnées en YAML (YAML *frontmatter*). Lorsque vous voulez fermer le bloc en écrivant trois points ou trois tirets, l'AutoCorrect de Zettlr les transforme en ellipse ou en tiret long, respectivement. Zettlr analysera alors l'ensemble du fichier en tant que YAML, et non en tant que Markdown, ce que nous voulons éviter. Afin d'empêcher manuellement l'application de l'AutoCorrect de Zettlr, voici comment procéder :
 
-Si vous trouvez que certains caractères ne devraient la plupart du temps jamais être remplacés, seulement en de rares occasions, envisagez de les supprimer de la table par défaut des remplacements AutoCorrect.
+1. Si vous utilisez l'AutoCorrect de type LibreOffice, il suffit de maintenir la touche Maj enfoncée tout en appuyant sur Espace ou Retour (l'AutoCorrection ne s'applique que sur Espace ou Retour). Cela incitera Zettlr à ne pas "corriger" automatiquement dans ce cas.
+2. Si vous utilisez l'AutoCorrect de type Word, appuyez simplement sur la touche Retour arrière dès que vous avez tapé un espace après l'application de la correction automatique. Cela annulera l'autocorrection et restaurera les caractères originaux.
 
-## J'utilise Linux et la suppression de fichiers ne les met pas à la poubelle !
+Si vous trouvez que certains caractères ne devraient la plupart du temps jamais être remplacés, seulement en de rares occasions, vous pouvez également envisager de les supprimer de la table par défaut des remplacements AutoCorrect.
 
-Zettlr ne supprime jamais complètement vos fichiers. Il ne fait que les déplacer vers la corbeille. Ainsi, si vous supprimez accidentellement un fichier dont vous avez besoin, vous pouvez toujours le restaurer. Sur les systèmes MacOS et Windows, la corbeille est activée par défaut, mais sur certaines distributions Linux, vous devez activer manuellement la fonctionnalité de la corbeille. Sous Linux, Zettlr (pour être plus précis : le framework Electron sous-jacent) utilise le binaire "gvfs-trash" pour déplacer les fichiers vers la corbeille. Pour éviter les chocs, il n'essaiera jamais de "retomber" sur la suppression complète des fichiers. Par conséquent, pour utiliser cette fonctionnalité, veuillez vous assurer que vous avez installé le `gvfs-trash` ! Sur Debian/Ubuntu, vous pouvez le faire en exécutant le code suivant dans un terminal :
+## J'utilise Linux et la suppression de fichiers ne les met pas à la corbeille !
+
+Zettlr ne supprime jamais complètement vos fichiers. Il ne fait que les déplacer vers la corbeille. Ainsi, si vous supprimez accidentellement un fichier dont vous avez besoin, vous pouvez toujours le restaurer. Sur les systèmes MacOS et Windows, la corbeille est activée par défaut, mais sur certaines distributions Linux, vous devez activer manuellement la fonctionnalité de la corbeille. Sous Linux, Zettlr (pour être plus précis : le framework Electron sous-jacent) utilise le binaire `gvfs-trash` pour déplacer les fichiers vers la corbeille. Pour éviter les problèmes, il n'essaiera jamais de "retomber" sur la suppression complète des fichiers. Par conséquent, pour utiliser cette fonctionnalité, veuillez vous assurer que vous avez installé le `gvfs-trash` ! Sur Debian/Ubuntu, vous pouvez le faire en exécutant le code suivant dans un terminal :
 
 ```bash
 $ sudo apt install gvfs-bin
 ```
 
-## À quoi devraient ressembler les liens réguliers Markdown pour fonctionner comme prévu ?
+## Comment écrire les liens pour s'assurer qu'ils ne soient pas cassés ?
 
-Par défaut, Zettlr rend les liens Markdown dans le format `[Your Link Text](your-link)` pour être cliquable (en maintenant la touche `Ctrl` ou `Alt`). Toutefois, les liens Markdown peuvent pointer à la fois vers des sites web et vers d'autres fichiers sur votre ordinateur. Vous pouvez omettre beaucoup d'informations de votre lien, et Zettlr utilise une heuristique pour déterminer les informations par lui-même, mais il pourrait déduire un faux contexte pour ce que vous voulez. Voici comment cela fonctionne :
+Par défaut, Zettlr affiche un rendu des liens Markdown `[Your Link Text](your-link)` sous forme cliquable (en maintenant la touche `Ctrl` ou `Alt`). Toutefois, les liens Markdown peuvent pointer à la fois vers des sites web et vers d'autres fichiers sur votre ordinateur. Vous pouvez omettre beaucoup d'informations de votre lien, et Zettlr utilise une méthode heuristique pour déterminer les informations par lui-même, qu'il faut connaître pour éviter qu'il déduise un mauvais contexte au lieu de ce que vous voulez. Voici comment cela fonctionne :
 
-- Les liens avec toutes les informations présentes (un protocole et un cheminement pleinement qualifié) ne seront pas modifiés. Exemples : `file:///home/foo/documents/test.md` et `http://www.example.com/`.
-- Liens relatifs avec le `file://`-protocol seront convertis en valeur absolue. Exemple : `file://./relative/file.md` deviendra `file:///home/foo/documents/relative/file.md`.
-- Les liens sans protocole seront supposés avoir `https://`. Exemple: `www.zettlr.com` devient `https://www.zettlr.com`.
-- Les chemins de fichiers absolus, mais sans le `file://`-protocol aura ce préfixe. Exemple : `/home/bar/documents/absolute.md` devient `file:///home/bar/documents/absolute.md`.
-- Les chemins d'accès relatifs aux fichiers avec et sans l'indicateur relatif (`./`) seront convertis en chemins d'accès absolus. Exemple : `./more/relative.md` et `more/relative.md` deviennent `file:///home/foo/documents/more/relative.md`. **Exception**: Ils résident dans le même dossier : `file.extension` sera dans ce cas traité comme un URI (sauf que le fichier est `.md`).
+- Les liens avec toutes les informations présentes (un protocole et un chemin pleinement qualifié) ne seront pas modifiés. Exemples : `file:///home/foo/documents/test.md` et `http://www.example.com/`.
+- Les liens relatifs avec le protocole `file://` seront convertis en valeur absolue. Exemple : `file://./relative/file.md` deviendra `file:///home/foo/documents/relative/file.md`.
+- Les liens sans protocole seront traités comme ayant `https://`. Exemple: `www.zettlr.com` devient `https://www.zettlr.com`.
+- Les chemins de fichiers absolus, mais sans le protocole `file://` seront traités comme ayant ce préfixe. Exemple : `/home/bar/documents/absolute.md` devient `file:///home/bar/documents/absolute.md`.
+- Les chemins d'accès relatifs aux fichiers avec et sans l'indicateur relatif (`./`) seront convertis en chemins d'accès absolus. Exemple : `./more/relative.md` et `more/relative.md` deviennent `file:///home/foo/documents/more/relative.md`. **Exception** s'ils résident dans le même dossier : `file.extension` sera dans ce cas traité comme un URI (sauf si le fichier est `.md`).
 
-Pour résumer : Si vous vous inquiétez de la façon dont vos liens sont traités, soyez plus explicite. Deux règles générales peuvent être utilisées pour obliger Zettlr à traiter un lien comme un fichier ou un lien web : Préfixer un `./`pour demander explicitement un lien _file_ et ajouter `/` pour demander explicitement un lien _web_.
+Pour résumer : si vous vous inquiétez de la façon dont vos liens sont traités, soyez plus explicite. Deux règles générales peuvent être utilisées pour obliger Zettlr à traiter un lien comme un fichier ou un lien web : préfixer par `./`pour demander explicitement un lien _file_ et ajouter `/` pour demander explicitement un lien _web_.
 
-## Les liens internes n'ouvrent pas le dossier correspondant!
+## Les liens internes n'ouvrent pas le fichier correspondant !
 
 Au cas où les liens internes utilisés pour relier les fichiers ne fonctionneraient pas comme prévu, veuillez vous assurer que vous avez fait les choses suivantes :
 
 1. Le lien est-il reconnu ? Zettlr vous permet de définir à quoi ressemblent les liens internes. Par défaut, ils sont encapsulés par `[[` et `]]`. Lorsque Zettlr reconnaît un lien interne, il le colore et si vous le survolez avec votre souris, le texte contenu doit être souligné. Dans le cas contraire, Zettlr ne pense pas que ce que vous avez écrit est un lien. Vous pouvez changer cela dans les paramètres.
-2. Avez-vous appuyé sur la touche `Alt`- or `Ctrl` en cliquant sur le lien ? Comme cliquer avec votre souris quelque part dans le texte signifie normalement que vous avez l'intention de changer quelque chose, vous devez dire à Zettlr que vous voulez effectivement suivre le lien.
-3. Avez-vous utilisé un nom de fichier ou une pièce d'identité valide ? Zettlr n'ouvre les fichiers que s'ils déclarent avoir _exactement_ l'ID ou le nom de fichier donné. Si rien ne se passe en cliquant sur le lien, cela signifie sûrement qu'un fichier avec l'ID ou le nom de fichier donné n'existe pas dans le système. Notez que vous devez omettre l'extension de fichier lorsque vous créez un lien. Par exemple, pour créer un lien vers`my-file.md`, il suffit de mettre `my-file` entre parenthèses.
+2. Avez-vous appuyé sur la touche `Alt`- or `Ctrl` en cliquant sur le lien ? Cliquer avec votre souris quelque part dans le texte signifie normalement que vous avez l'intention de changer quelque chose et sert donc à simplement positionner le curseur : vous devez "dire" à Zettlr que vous voulez effectivement suivre le lien.
+3. Avez-vous utilisé un nom de fichier ou un identifiant (ID) valide ? Zettlr n'ouvre les fichiers que s'ils ont _exactement_ l'ID ou le nom de fichier donné. Si rien ne se passe en cliquant sur le lien, cela signifie sûrement qu'un fichier avec l'ID ou le nom de fichier donné n'existe pas dans le système. Notez que vous devez omettre l'extension de fichier lorsque vous créez un lien. Par exemple, pour créer un lien vers`my-file.md`, il suffit de mettre `my-file` entre parenthèses.
 4. Le fichier est-il actuellement chargé dans Zettlr ? La liaison interne ne fonctionne évidemment que si Zettlr a lu le fichier.
 
 ## Je connais LaTeX et je veux l'utiliser aussi dans mes fichiers Markdown. Est-ce possible ?
 
-Oui, il suffit d'écrire vos éléments (statements)`LaTeX`où vous les voulez. Dès que vous exportez au format PDF, Pandoc s'occupe du reste et les déclarations sont interprétées par le moteur PDF. Malheureusement, le surlignage de la syntaxe `LaTeX` n'est pas supporté. Par ailleurs, veuillez noter que Pandoc va supprimer tout bloc `LaTeX`avant d'exporter vers un autre format que le PDF, ce qui signifie que les informations entre `\begin` et `\end`, par exemple, sera complètement absent du dossier final. Sur l'export HTML, tous les blocs`LaTeX`seront conservés, mais pas convertis en autre chose.
+Oui, il suffit d'écrire vos déclarations LaTeX là où vous les voulez. Lorsque que vous exportez au format PDF, Pandoc les prend en compte et les déclarations sont interprétées par le moteur PDF. Malheureusement, le surlignage de la syntaxe LaTeX n'est pas supporté. Par ailleurs, veuillez noter que Pandoc va supprimer tout bloc LaTeX avant d'exporter vers un autre format que le PDF, ce qui signifie que les informations entre `\begin` et `\end`, par exemple, seront complètement absentes de l'export. Pour les exports en HTML, tous les blocs LaTeX sont conservés, mais pas convertis en autre chose.
 
-## Je n'arrive pas à aligner le texte juste ou correct !
+## Je ne peux pas justifier le texte ou l'aligner à droite ?
 
-Ce n'est pas un bug, c'est une fonctionnalité : Markdown n'a pas les signes de formatage y relatifs car le texte doit toujours être justifié ou aligné à gauche et n'appartient donc pas à l'ensemble des formats de blocs nécessaires que propose Markdown. Pourtant, vous pouvez toujours utiliser des commandes `LaTeX`pour les rendre à gauche ou à droite. Il suffit d'inclure le texte que vous souhaitez aligner à droite ou justifier dans `\begin{<option>}` et `\end{<option>}`, où `<option>` peut soit se référer à `flushleft`, `flushright` ou bien mettre `\justify` devant un paragraphe que vous voulez justifier. [Learn more at sharelatex.com](https://www.sharelatex.com/learn/Text_alignment).
+Ce n'est pas un bug mais une fonctionnalité : Markdown n'inclut pas de signes pour ce type de formatage qui relève de la mise en page spécifique à chaque type d'export. Vous pouvez ainsi utiliser des commandes LaTeX pour modifier localement la justification du texte dans l'export PDF. Vous pouvez inclure le texte que vous souhaitez aligner à droite ou justifier entre `\begin{<option>}` et `\end{<option>}`, où `<option>` peut soit se référer à `flushleft`, `flushright` ; vous pouvez également mettre `\justify` devant un paragraphe que vous voulez justifier. [Plus d'infos sur ces commandes  sur Overleaf](https://www.overleaf.com/learn/latex/Text_alignment).
 
-## En sortie PDF, je souhaite que certaines rubriques ne soient pas numérotées/numérotées dans la table des matières
+## Dans l'export PDF, je souhaite que certains titres ne soient pas numérotés / soient exclus de la table des matières.
 
-C'est une particularité de Pandoc. Ajouter les classes spéciales (simplement signe moins) `-`ou `.unlisted` respectivement. Le moins empêche les chiffres, tandis que "non listé" empêche le titre d'apparaître dans la table des matières. Notez que cela ne s'applique qu'à la sortie PDF.
+C'est possible grâce à Pandoc, qui ajoute quelques extensions à la syntaxe Markdown de base. Parmi elles, l'ajout des attributs à certains éléments du texte sous la forme `{.attribut}`. La plupart des attributs sont nommés (en anglais) ; certains utilisés fréquemment ont une forme raccourcie pour des raisons pratiques. Ainsi vous pouvez inclure les attributs `-` et `.unlisted` entre accolades après un titre : le moins empêche la numérotation du titre, tandis que "non listé" empêche le titre d'apparaître dans la table des matières. Notez que cela ne s'applique qu'à la sortie PDF.
 
 Examples:
 
 ```
-# This heading will be unnumbered, but in the ToC {-}
+# Ce titre ne sera pas numéroté, mais dans la TdM {-}
 
-# This heading will be numbered, but not in the ToC {.unlisted}
+# Ce titre sera numéroté, mais pas dans la TdM {.unlisted}
 
-# This heading will both be unnumbered, and hidden from the ToC {- .unlisted}
+# Ce titre sera à la fois non numéroté et absent de la TdM {- .unlisted}
 ```
 
-> Note that the special classes need to be the last thing on the line. Even comments will break this behaviour.
+> Notez que les classes spéciales doivent être la dernière chose sur la ligne du titre. Un commentaire en fin de ligne, par exemple, empêche les attributs d'être pris en compte.
 
-## Je veux utiliser des sauts de ligne simples et ne pas créer de nouveaux paragraphes. Lorsque je clique une fois sur la touche Entrée, le saut de ligne est supprimé !
+Pour en savoir plus, consulter [la documentation de Pandoc sur les attributs de titre](https://pandoc.org/MANUAL.html#heading-identifiers) (en anglais).
 
-Pour forcer Pandoc à rendre des sauts de ligne simples en tant que tels, terminez votre ligne par une barre oblique inversée (`\`) ou deux espaces. La barre oblique inversée ainsi que les deux espaces ne seront pas rendus dans le fichier résultant.
+## Je veux insérer un simple retour à la ligne manuel, sans créer de nouveau paragraphe. Comment faire ?
+
+Pour forcer Pandoc à créer un retour à la ligne, terminez votre ligne par une barre oblique inversée (`\`) ou deux espaces. La barre oblique inversée ou les deux espaces ne seront pas rendus dans le fichier résultant mais seront remplacés par un retour à la ligne comme voulu.
 
 ## Ai-je vraiment besoin de Pandoc ou de LaTeX ?
 
-Pour l'exportation en HTML simple, non. Pour tous les autres formats d'exportation, oui. Zettlr dépend de ces programmes pour permettre l'exportation des fichiers. Mais ne vous inquiétez pas : ils sont Open Source et donc totalement gratuits, et disponibles sur tous les systèmes d'exploitation !
+Pour l'exportation en HTML simple, non. Pour tous les autres formats d'exportation, oui. Zettlr dépend de ces programmes pour permettre l'exportation des fichiers. Mais ne vous inquiétez pas : ils sont Open Source, gratuits et disponibles sur tous les systèmes d'exploitation !
 
 ## Comment installer Pandoc ou LaTeX ?
 
-Please refer to the [setup guide](install.md) for instructions on how to set up Pandoc and LaTeX on your system.
+Veuillez consulter le [guide d'installation](install.md) pour savoir comment installer Pandoc et LaTeX sur votre système.
 
 ## Zettlr ne semble pas trouver Pandoc et LaTeX, qui sont pourtant installés !
 
-Cela peut arriver si votre ordinateur a décidé d'installer le logiciel dans un répertoire non standard. Zettlr fera de son mieux pour localiser les applications mais peut échouer si elles sont enterrées quelque part. C'est là que les options de cheminement dans les préférences entrent en jeu. Au cas où Zettlr ne trouverait aucun des binaires, vous pouvez entrer le **chemin complet** dans les champs de texte appropriés de l'onglet `Avancé`-.
+Cela peut arriver si votre ordinateur a décidé d'installer le logiciel dans un répertoire non standard. Zettlr fera de son mieux pour localiser les applications mais peut échouer si elles sont situées à un endroit inattendu. C'est là qu'entre en jeu l'option pour spécifier le chemin de ces logiciels dans les Préférences. Au cas où Zettlr ne trouverait pas d'exécutable pour Pandoc ou LateX, vous pouvez entrer le **chemin complet** dans les champs de texte appropriés de l'onglet "Avancé" des Préférences.
 
-On Windows, you should never encounter this issue, as long as you leave the default installation path during install set to the default `Program Files` directory of Windows. If you wanted to install the programs to different locations, rendering Zettlr unable to find them, simply search your system using the Explorer for two files, the first being `pandoc.exe` and the second being `xelatex.exe`. Copy the full path (including the executable's name!) to the appropriate text field in the Zettlr preferences.
+Sous Windows, vous ne devriez jamais rencontrer ce problème tant que vous laissez le chemin d'installation par défaut défini lors de l'installation comme étant le répertoire "Program Files" par défaut de Windows. Toutefois vous pouvez souhaiter installer les programmes à des endroits différents. Il vous suffit alors de rechercher les exécutables sur votre système à l'aide de l'explorateur, le premier étant `pandoc.exe` et le second `xelatex.exe`. Copiez le chemin d'accès complet (y compris le nom de l'exécutable !) dans le champ de texte approprié dans les Préférences de Zettlr.
 
-On macOS you can easily find the path by opening up `Terminal.app` (it's in your Applications folder under `Other`) and then type `which pandoc` _or_ `which xelatex`, depending on which software Zettlr does not find. Terminal will simply output the full path to the program.
+Sous macOS, vous pouvez facilement trouver les chemins manquants en ouvrant l'application Terminal (qui se trouve dans votre dossier Applications sous "Outils" ou bien "Autres") et en saisissant `which pandoc` _ou_ `which xelatex`, selon le logiciel que Zettlr ne trouve pas. Le Terminal affichera simplement le chemin complet du programme, que vous pouvez copier dans le champ de texte approprié dans les Préférences de Zettlr.
 
-On Linux distributions, you also need to open up a Command Line/Terminal and use the same commands as on macOS: `which pandoc` for Pandoc and `which xelatex` for LaTeX.
+Sous Linux, vous devez également ouvrir la ligne de commande et utiliser les mêmes commandes que sur macOS : `which pandoc` pour Pandoc et `which xelatex` pour LaTeX.
 
-## À propos de l'exportation, Zettlr affirme que le moteur PDF n'a pas été reconnu !
+## Au moment de l'export en PDF, Zettlr affirme que le moteur PDF n'a pas été reconnu !
 
-Il s'agit d'une erreur Pandoc courante, indiquant que votre version de Pandoc est antérieure à 2.x. Lorsque Zettlr vous présente le message d'erreur suivant, cela signifie que vous devez passer à Pandoc 2.x :
+Il s'agit d'une erreur Pandoc courante, indiquant que votre version de Pandoc est antérieure à 2.x. Lorsque Zettlr vous présente le message d'erreur suivant :
 
 `pandoc: unrecognized option '--pdf-engine=xelatex' Try pandoc --help for more information.`
 
-The reason is that with Pandoc 2.0, the older option `--latex-engine` was renamed to `--pdf-engine`. [See more in Pandoc's changelog](https://github.com/jgm/pandoc/blob/master/changelog#L4349).
+Cela signifie que vous devez passer à Pandoc 2.x.
 
-## Sur Export vers PDF, je reçois constamment des messages d'erreur !
+La raison est qu'à partir de Pandoc 2.0, l'ancienne option `--latex-engine` a été rebaptisée `--pdf-engine`. [Pour en savoir plus, consultez le journal des modifications de Pandoc](https://github.com/jgm/pandoc/blob/master/changelog#L4349).
 
-Pour les premières exportations, il faut s'attendre à ce que cela soit tout à fait normal. Zettlr transmet simplement le fichier à Pandoc, qui le transmet à LaTeX. Mais le modèle que Zettlr utilise pour vos exportations PDF nécessite quelques paquets supplémentaires qui ne sont pas toujours installés lors de l'installation de LaTeX.
+## Au moment de l'export en PDF, je reçois constamment des messages d'erreur !
 
-L'erreur la plus courante ressemble à ceci :
+Pour les premières exportations, cela peut arriver. Zettlr transmet le fichier à Pandoc, qui le transmet à LaTeX. Mais le modèle LaTeX que Zettlr utilise pour les exports PDF nécessite un certain nombre de paquets qui ne sont pas toujours installés par défaut dans les distributions LaTeX de base. L'erreur la plus courante ressemble à ceci :
 
-**LaTeX Error: File \<some name\>.sty not found.**
+**LaTeX Error: File \<nom du paquet\>.sty not found.**
 
-Cela signifie simplement qu'un certain paquet n'a pas été trouvé (ils se terminent par `.sty`). Sous Windows, ces paquets doivent être installés automatiquement dès qu'ils sont nécessaires ; sous MacOS et Linux, il suffit d'exécuter la commande `tlmgr install <some name>`.
+Cela signifie simplement qu'un certain paquet n'a pas été trouvé (ils se terminent par `.sty`). Sous Windows, ces paquets sont installés automatiquement dès qu'ils sont requis par un fichier LaTeX ; sous MacOS et Linux, il suffit d'exécuter la commande `tlmgr install <nom du paquet>`.
 
-En cas d'autres erreurs, Zettlr vous permet de copier et de coller du texte à partir du message d'erreur, car dans presque tous les cas, une courte recherche Google mène à une solution ; et dans presque tous les cas, la seule action requise est l'installation d'un autre paquet.
+En cas d'autres erreurs, Zettlr vous permet de copier le texte du message d'erreur et dans presque tous les cas, une courte recherche Google mène à une solution, dont la seule action requise la plupart du temps l'installation d'un autre paquet.
 
 ## J'ai trouvé un bug !
 
-C'est une excellente nouvelle ! Enfin, pas géniale, mais c'est bien que vous l'ayez trouvée ! Dans ce cas, veuillez vous rendre sur [GitHub](https://github.com/Zettlr/Zettlr/) et ouvrir un dossier (_issue_) afin que nous sachions ce qui se passe et puissions travailler à la résolution du bug.
+C'est une excellente nouvelle ! Enfin, pas géniale, mais c'est bien que vous l'ayez trouvé ! Dans ce cas, veuillez vous rendre sur [GitHub](https://github.com/Zettlr/Zettlr/) et ouvrir un dossier (_issue_) afin que nous sachions ce qui se passe et puissions travailler à la résolution du bug.
 
 ## J'ai une requête de fonctionnalité ! / J'ai une suggestion pour rendre une fonctionnalité plus efficace !
 
-C'est bon à entendre ! Nous dépendons toujours de l'expérience d'autres personnes avec l'application pour améliorer son efficacité et son adéquation à différentes situations. Dans ce cas, veuillez vous rendre sur [GitHub](https://github.com/Zettlr/Zettlr/) et ouvrir un dossier afin que nous puissions aller droit au but.
+C'est bon à entendre ! Nous dépendons toujours de l'expérience d'autres personnes avec l'application pour améliorer son efficacité et son adéquation à différentes situations. Dans ce cas, veuillez vous rendre sur [GitHub](https://github.com/Zettlr/Zettlr/) et ouvrir un dossier (_issue_) afin que nous puissions aller droit au but.
 
 ## Qu'en est-il de ma vie privée ? Zettlr transfère-t-il des données, ou ne dois-je pas m'inquiéter ?
 
-Zettlr, c'est la vie privée avant tout. Il n'envoie aucune donnée et il est pleinement fonctionnel hors ligne. Pourtant, il existe un cas où Zettlr envoie des données sur le web : La vérification de la mise à jour. Chaque fois que vous ouvrez Zettlr, ou que vous utilisez l'élément de menu, Zettlr se connecte à l'API Zettlr pour récupérer une liste de toutes les versions. Cette liste est ensuite utilisée pour déterminer si vous utilisez la dernière version ou non. Lors de la connexion, Zettlr recevra votre adresse IP et saura qu'une application Electron accède à l'API. L'application transmettra également votre type de système d'exploitation et l'ID de l'application.
+Zettlr met la vie privée avant tout. Il est pleinement fonctionnel hors ligne. Il n'existe qu'un cas où Zettlr envoie des données sur le web : lorsqu'il vérifie l'existence d'une mise à jour. Chaque fois que vous ouvrez Zettlr, ou que vous sélectionnez l'élément de menu correspondant, Zettlr se connecte à l'API Zettlr pour récupérer une liste de toutes les versions. Cette liste est ensuite utilisée pour déterminer si vous utilisez la dernière version ou non. Lors de la connexion, Zettlr recevra votre adresse IP et saura qu'une application Electron accède à l'API. L'application transmettra également votre type de système d'exploitation et l'ID de l'application.
 
-Ces données ne seront jamais vendues à des tiers. C'est simplement parce que nous aimons les statistiques et que nous sommes toujours intéressés de savoir qui utilise l'application. Néanmoins, nous ne pouvons identifier personne sur la base de ces données, c'est beaucoup trop grossier pour cela. Nous sommes Open Source, pas Facebook.
+Ces données ne seront jamais vendues à des tiers. C'est simplement parce que nous aimons les statistiques et que nous sommes toujours intéressés par le fait de savoir qui utilise l'application. Néanmoins, nous ne pouvons identifier personne sur la base de ces données, qui sont beaucoup trop brutes pour cela. Nous sommes Open Source, pas Facebook.

--- a/docs/fr/get-involved.md
+++ b/docs/fr/get-involved.md
@@ -1,51 +1,51 @@
-# Get involved
+# Impliquez-vous
 
-Do you want to make Zettlr an even better app? That's great! Whether you are a user, want to provide a new translation, or get into developing, you've come to the right place!
+Vous voulez faire de Zettlr une application toujours meilleure ? C'est génial ! Que vous soyez utilisateur, que vous souhaitiez fournir une nouvelle traduction ou que vous vous lanciez dans le développement, vous êtes au bon endroit !
 
-## General Resources
+## Ressources
 
-Zettlr has a vibrant community helping each other all around the net. The following list contains the common places to start for any issue you might have.
+Zettlr a une communauté dynamique qui s'entraide tout autour du Net. La liste suivante contient les lieux à partir desquels vous pouvez commencer pour tout problème que vous pourriez avoir.
 
-* [Zettlr user forum](https://forum.zettlr.com) — Go here to ask general questions, discuss workflows and concepts of Zettlr and even share your custom themes!
-* [Zettlr subreddit](https://www.reddit.com/r/Zettlr) — The Zettlr subreddit is meant for the redditors in the community.
-* [The official Twitter account](https://www.twitter.com/Zettlr) — Here you can follow the updates to the app in real time. It's the only place where we regularly announce everything we do. Additionally, we engage in most discussions, so if you have questions, you can drop them here.
-* [The official Facebook page](https://fb.me/Zettlrapp) — Here you can message us, if you don't have a Twitter account. Normally, we receive notifications and answer asap, but can't promise it. We only have this page because, well — one simply has a Facebook page, nowadays 🤷‍♂️
-* [Our YouTube channel](https://www.youtube.com/c/Zettlr) — If you are more like the visual type of person, you can find some introductory videos here.
-* [The GitHub issue tracker](https://github.com/Zettlr/Zettlr/issues) — This is the core of our endeavours to make the app better and better. If you spot a bug, have a suggestion or want to propose a feature, here's the right place. Nevertheless, especially when it comes to questions regarding the user workflow or new features, **it's best to discuss your ideas on the forum or on reddit first**.
+* [Forum d'utilisateurs de Zettlr](https://forum.zettlr.com) - Venez ici pour poser des questions générales, discuter de *workflows* et des concepts de Zettlr, partager vos thèmes personnalisés…
+* [Subreddit Zettlr](https://www.reddit.com/r/Zettlr) - Le subreddit r/Zettlr pour les *redditors* de la communauté.
+* [Le compte Twitter officiel](https://www.twitter.com/Zettlr) - Vous pouvez y suivre les mises à jour de l'application en temps réel. C'est l'endroit où nous annonçons le plus régulièrement tout ce que nous faisons. De plus, nous participons activement à la plupart des discussions, donc si vous avez des questions, vous pouvez les poser sans hésitation.
+* [La page officielle de Facebook](https://fb.me/Zettlrapp) - Ici vous pouvez nous envoyer un message, si vous n'avez pas de compte Twitter. Normalement, nous recevons des notifications et répondons le plus rapidement possible, mais nous ne pouvons pas le garantir.
+* [Notre chaîne YouTube](https://www.youtube.com/c/Zettlr) - Si vous fonctionnez mieux avec de la vidéo, vous pouvez trouver quelques vidéos d'introduction ici.
+* [Le suivi des tickets (*issues*) sur GitHub](https://github.com/Zettlr/Zettlr/issues) - C'est le cœur de nos efforts pour améliorer l'application encore et toujours. Si vous repérez un bug, avez une suggestion ou souhaitez proposer une fonctionnalité, c'est le bon endroit. Néanmoins, surtout lorsqu'il s'agit de questions concernant les *workflows* des utilisateurs ou bien de nouvelles fonctionnalités, **il est préférable de discuter de vos idées sur le forum ou sur reddit en premier**.
 
-## User Contributions
+## Contributer en tant qu'utilisateur
 
-As a user who wants a good-looking, well-working writing app, just keep your eyes open for any error the app might produce and, more importantly, tell us how to make the workflow more efficient! We can only judge for our own workflow, so to make the app better for you as well, we need to know how. Always remember: We cannot build a workflow as-is into the design but have to make concessions to other workflows, but we'll try to make features more accessible or working smoother as long as the trade-offs for the existing workflows and the new suggestion are not too hard.
+En tant qu'utilisateur désireux de disposer d'une application d'écriture à la fois belle et efficace, vous pouvez garder l'œil ouvert pour détecter toute erreur que l'application pourrait produire. Veuillez signaler les bugs en ouvrant un ticket (*issue*) sur le dépôt GitHub. De cette façon, nous sommes en mesure de répondre rapidement au rapport et de traiter directement le problème.
 
-Please report bugs by opening up issues on the GitHub repository. This way we are able to to quickly respond to the report and directly get to handle the problem.
+Vous pouvez aussi nous dire comment rendre votre flux de travail plus efficace ! Nous ne pouvons juger que de nos propres processus, donc pour améliorer l'application pour vous aussi, nous devons savoir dans quelle direction travailler. Retenez que nous ne pouvons pas intégrer un flux de travail entièrement nouveau tel quel dans la conception, nous devons faire des concessions à d'autres processus, mais nous essaierons de rendre les fonctionnalités plus accessibles ou de les faire fonctionner plus facilement tant que les compromis entre les flux de travail existants et la nouvelle suggestion ne sont pas trop difficiles.
 
-## Translating the App
+## Traduire l'application
 
-We welcome any help in translating the app in all languages of this planet. Translations are managed on our Translation Server. To translate, you'll need to create an account, which is only used as an anti-spam measure. Additionally — but only if you want to — you will be credited using your username in all generated translations.
+Toute aide à la traduction de l'application dans toutes les langues de la planète est la bienvenue. Les traductions sont gérées sur notre serveur de traduction. Pour traduire, vous devez créer un compte, qui n'est utilisé que comme mesure antispam. De plus - mais seulement si vous le souhaitez - vous serez crédité en utilisant votre nom d'utilisateur dans toutes les traductions générées.
 
-Translating is simple. Just click on any language on the main page to see the list of all identifiers and all existing translations:
+Traduire est simple. Il suffit de cliquer sur n'importe quelle langue sur la page principale pour voir la liste de tous les identifiants et de toutes les traductions existantes :
 
-![Translation Keys](img/translations_list.png)
+![Clés de traduction](img/translations_list.png)
 
-On the left side you'll see all translation IDs. They will mostly be self-explanatory. If you don't know where to start, simply have a look at the English translation and at the app. Then you'll know which translation IDs will correspond to which elements.
+Sur le côté gauche, vous verrez tous les ID de traduction. Elles seront pour la plupart explicites. Si vous ne savez pas par où commencer, jetez simplement un coup d'œil à la traduction anglaise et à l'application. Vous saurez alors à quels éléments correspondent les ID de traduction.
 
-We've implemented a user-based quality management system in the service, which consists in you being able to vote on existing translations. So even if you don't want to translate yourself, you can look through all translations and vote for the one you deem correct. Whenever somebody downloads a translation, the system will take the best-rated translation strings to ensure all translations are verified by you, our users!
+Nous avons mis en place dans le service un système de gestion de la qualité basé sur l'utilisateur, qui consiste à vous permettre de voter sur les traductions existantes. Ainsi, même si vous ne souhaitez pas traduire vous-même, vous pouvez consulter toutes les traductions et voter pour celle que vous jugez correcte. Chaque fois que quelqu'un télécharge une traduction, le système prend les chaînes de traduction les mieux notées pour s'assurer que toutes les traductions sont vérifiées par vous, nos utilisateurs !
 
-[For more information, please see the short guide to our translation service](https://translate.zettlr.com/welcome).
+[Pour plus d'informations, veuillez consulter le petit guide de notre service de traduction](https://translate.zettlr.com/welcome).
 
-## Developing
+## Contribuer au développement
 
-To start developing, simply [fork the repository](https://github.com/Zettlr/Zettlr), work on your features, bug fixes, etc. and then open pull-requests. Please remember to **only PR to the develop branch!** The master-branch is only pushed to once a new release is being drafted. So if you are developing a new feature and a new version of Zettlr is released, you can simply pull the `origin master` to be up to date again and continue writing your feature.
+Pour commencer le développement, il suffit de [créer une copie du dépôt](https://github.com/Zettlr/Zettlr), de travailler sur vos fonctionnalités, les corrections de bogues, etc. puis de soumettre une requête (*pull request, PR*). N'oubliez pas de **seulement faire une requête sur la branche de développement**. La branche `master` n'est ciblée que lorsqu'une nouvelle version est en cours de préparation. Ainsi, si vous développez une nouvelle fonctionnalité et qu'une nouvelle version de Zettlr est publiée entretemps, vous pouvez simplement récupérer `origin master` pour être à nouveau à jour et continuer à écrire votre fonctionnalité.
 
-If you are beginning to develop a feature, it also may be wise to announce that using a new issue to just let the rest know that somebody is already doing it to maximise efficiency!
+Si vous commencez à développer une fonctionnalité, il peut également être judicieux de l'annoncer en ouvrant un nouveau ticket (*issue*), vous faites savoir aux autres que quelqu'un le fait déjà pour maximiser l'efficacité !
 
-### Starting to Develop
+### Débuter le développement
 
-To set everything up, make sure to start your favourite IDE and spin up your terminal. Zettlr is based on a [NodeJS](https://nodejs.org/)-stack, so you'll need to have the current Node-Server installed on your system, and a Node Package Manager. Zettlr prefers [Yarn](https://yarnpkg.com/), but of course you can also use NPM (this will be installed alongside Node).
+Pour tout mettre en place, lancez votre IDE et votre interface en ligne de commande favorite. Zettlr est basé sur un *stack* [NodeJS](https://nodejs.org/), vous devrez donc avoir la version actuelle de Node-Server installée sur votre système, et un gestionnaire de paquets pour Node. Zettlr préfère [Yarn](https://yarnpkg.com/), mais vous pouvez bien sûr aussi utiliser NPM (qui sera installé à côté de Node).
 
-Then make sure to initialise everything.
+Assurez-vous ensuite de tout initialiser.
 
-**With Yarn**
+**Avec Yarn**
 
 ```bash
 $ git clone https://github.com/Zettlr/Zettlr.git
@@ -55,7 +55,7 @@ $ cd source
 $ yarn install
 ```
 
-**With NPM**
+**Avec NPM**
 
 ```bash
 $ git clone https://github.com/Zettlr/Zettlr.git
@@ -65,35 +65,37 @@ $ cd source
 $ npm install
 ```
 
-The second `install` in the source-directory is necessary, because we make use of [electron-builder](https://www.electron.build/)'s two-directories-structure.
+La seconde `install` dans le répertoire source est nécessaire, parce que nous utilisons la structure à deux répertoires de [electron-builder](https://www.electron.build/).
 
-### CLI-Commands
+### Interface en ligne de commande
 
-Zettlr ships with a lot of useful commands that you can make use of in your development process. Let's list all of them.
+Zettlr est livré avec un grand nombre de commandes utiles que vous pouvez utiliser dans votre processus de développement. Listons-les toutes.
 
-> You can run any of these commands either with `npm run <command>` or `yarn <command>`, depending on your package manager. Make sure to run them from the Zettlr main-directory.
+> Vous pouvez exécuter n'importe laquelle de ces commandes soit avec `npm run <command>` ou `yarn <command>`, selon votre gestionnaire de paquets. Assurez-vous de les exécuter depuis le répertoire principal de Zettlr.
 
-* `start`: Starts the application.
-* `build:quick`: Quickly builds the app for your operating system (if supported by electron-builder) and outputs it to `/release`.
-* `release:this`: The same as `build:quick`, but the app will also be packaged (as a `.dmg`-file on macOS, a `.exe`-installer on Windows, or a Linux package).
-* `release:mac`: Explicitly build a release for macOS.
-* `release:win`: Explicitly build a release for Windows.
-* `release:linux`: Explicitly build a release for Linux.
-* `less`: Runs the LESS converter to convert the source files in `/resources/less` to the final CSS files in `source/common/assets/css`. Whenever you make changes to the styles, you should run this command.
-* `less:extract`: Extracts all CSS IDs and classes from the source files and outputs them to `/resources/css_list.md`, one per line. This is only used to generate our [Custom CSS reference list](https://docs.zettlr.com/core/custom-css/#complete-css-class-and-id-reference).
-* `handlebars`: This starts up the Handlebars precompiler to convert the templates (for dialogs and popups) into those that will be shipped with the app in the directory`/source/common/assets/tpl`. Whenever you change anything in a file in `/resources/templates`, you should run this, lest your changes won't be visible.
-* `lang:refresh`: Downloads the most recent version of the default translations `German (Germany)`, `English (United States)`, `English (United Kingdom)`, and `French (France)` from [translate.zettlr.com](https://translate.zettlr.com/) and places them into the directory `/source/common/lang`.
-* `reveal:build`: Rebuilds the template for generating revealJS-presentations.
+* `start` : Démarre l'application.
+* `build:quick` : Construit rapidement l'application pour votre système d'exploitation (si elle est supportée par electron-builder) et la déplace dans `/release`.
+* `release:this` : Même chose que `build:quick`, mais l'application sera également empaquetée (sous forme de fichier `.dmg` sur macOS, d'installateur `.exe` sur Windows, ou de paquet Linux).
+* `release:mac` : Construire explicitement une version pour macOS.
+* `release:win` : Construire explicitement une version pour Windows.
+* `release:linux` : Construire explicitement une version pour Linux.
+* `less` : Exécute le convertisseur LESS pour convertir les fichiers sources dans `/resources/less` en fichiers CSS finaux dans `source/common/assets/css`. Chaque fois que vous modifiez les styles, vous devez exécuter cette commande.
+* `less:extract` : Extrait tous les ID et classes CSS des fichiers sources et les affiche dans `/resources/css_list.md`, un par ligne. Cette commande est uniquement utilisée pour générer notre [référence CSS personnalisée](https://docs.zettlr.com/core/custom-css/#complete-css-class-and-id-reference).
+* `handlebars` : Ceci démarre le précompilateur Handlebars pour convertir les modèles (pour les dialogues et les popups) sous la forme qui sera livrée avec l'application dans le répertoire `/source/common/assets/tpl`. Chaque fois que vous modifiez quoi que ce soit dans un fichier dans `/resources/templates`, vous devez exécuter cette commande, sans quoi vos modifications ne seront pas visibles.
+* `lang:refresh` : Télécharge la version la plus récente des traductions par défaut `German (Germany)`, `English (United States)`, `English (United Kingdom)`, et `French (France)` de [translate.zettlr.com](https://translate.zettlr.com/) et les place dans le répertoire `/source/common/lang`.
+* `reveal:build` : Reconstruit le modèle des présentations Reveal-js.
 
-Apart from these commands, there is one "master-command" that we use to run a full release cycle of Zettlr. It resides in `/scripts/make.sh` and is a Shell-command that will run most of the aforementioned commands to generate the installers for Windows, macOS, Debian-based Linux distributions, and Fedora-based Linux distributions. Additionally, it will generate a `SHASUMS.txt`-file containing checksums of all four installers.
+En dehors de ces commandes, il y a une "commande maître" que nous utilisons pour exécuter un cycle complet pour chaque nouvelle version de Zettlr. Elle réside dans `/scripts/make.sh` et est une commande Shell qui exécutera la plupart des commandes mentionnées ci-dessus pour générer les installateurs pour les distributions Windows, macOS, Linux basées sur Debian et les distributions Linux basées sur Fedora. De plus, elle génère un fichier `SHASUMS.txt` contenant les *checksums* des quatre installateurs.
 
-> Attention: Currently the Make-script requires Yarn and macOS. It does not work with NPM or on any other platform. This is due to the command to generate SHA256 checksums, which differs between macOS and Linux distributions.
+> Attention : actuellement, le script Make-script nécessite Yarn et macOS. Il ne fonctionne pas avec NPM ni sur aucune autre plate-forme. Ceci est dû à la commande de génération de sommes de contrôle SHA256, qui diffère entre les distributions macOS et Linux.
 
-### Project Structure
+### Structure du projet
 
-Now to the real technical stuff: The project's structure! In most respects, the structure adheres to the best practices concerning Electron application development. Nevertheless, the application is _huge_, and therefore you'll need some guidance.
+Passons maintenant aux choses vraiment techniques : la structure du projet ! Dans la plupart des cas, la structure se conforme aux bonnes pratiques du développement d'applications électroniques. Néanmoins, l'application est très étalée, et vous aurez donc besoin de quelques conseils.
 
-Let's first cover the directory structure (this is a non-exhaustive list; only the folders and files you'll mostly be working on are covered):
+Commençons par la structure des répertoires (cette liste n'est pas exhaustive ; seuls les répertoires et les fichiers sur lesquels vous travaillerez le plus sont couverts) :
+
+> Traduction française à venir.
 
 ```
 Zettlr                 // The root directory
@@ -154,3 +156,71 @@ Zettlr                 // The root directory
 |
 + CHANGELOG.md          // Contains a detailed list of all changes.
 ```
+
+### Terminology
+
+A module is not necessarily always a module, but directories and folders can mean the same. Due to semantic ambiguities, we decided to include this glossary section so that terms that are frequently thrown around in the ecosystem of Zettlr are well understood.
+
+#### Folder/Directory
+
+Used interchangeably to denote folders on a file system. Mostly, Zettlr will try to use "directory", but folder effectively means the same.
+
+#### Sidebar
+
+Refers to the left sidebar in the GUI that contains the loaded root directories.
+
+#### Root (directory/file)
+
+This means a top-level directory that is visible in the app. This does _not_ mean a root of your overall file system. Example: While `/home` is a root-level directory on a Linux installation, `/home/user/Zettlr` is a root directory _in the context of Zettlr_, if it is loaded as a root-directory. All directories and files within that directory are not roots, then.
+
+#### Attachment Sidebar
+
+Refers to the right sidebar in the GUI that contains additional files and the bibliography. We are not happy with the term, so if you have a better one, please come forward!
+
+#### Module
+
+While Zettlr generally follows the definition of modules as seen on [NPM](https://www.npmjs.com/get-npm), there are also "sub-modules" within the main process, such as the File System Abstraction Layer or the exporter. These are treated as modules because these are self-sustaining modules that are being accessed by the app and expose an API that the app uses.
+
+#### Service Provider
+
+A service provider is a class which is instantiated during boot and then keeps running until the app is shut down. These providers provide functionality by attaching certain functional objects (some sort of internal API) to the `global`-object. One example is the log provider which can be used for logging, e.g. `global.log.verbose('A message!')`. Another one is the configuration, which can be accessed similarly, e.g. `global.config.get('config.value')`.
+
+#### Command
+
+While a command within the Zettlr-ecosystem mainly denotes the thing you'd generally associate with the term in a software engineering context, there is one class of `commands` that is special. Mostly, if we talk about commands, we mean one of the commands in the `source/main/commands`-subdirectory. These commands are called whenever the user performs a conscious action that does something, such as opening a file, exporting, or saving the file.
+
+#### Window
+
+In the Zettlr-context, a window not only comprises a literal window that can be opened by the app, but much more. In general, due to the structure of Electron-applications, a window consists of one control class in the main process, one control class in the respective renderer process that is started for each window, and an accompanying HTML-file that is loaded into the window.
+
+#### Dialog
+
+A dialog in Zettlr is an overlay over the main window that shows information and can also provide forms for settings, etc. Example of dialogs are the preferences, the tag manager, the tag cloud, or the PDF preferences.
+
+#### Popup
+
+A popup is similar to the dialogs, only that it does not create a full-page overlay but a smaller onscreen-window with an arrow pointing to the reference element. It is not to be confused with the tippy.js-tooltips that are not interactive.
+
+#### Notification
+
+A notification primarily means the onscreen-notifications that are shown in the top-right corner of the application.
+
+#### Toolbar
+
+The toolbar is the collection of buttons on the top edge of the main Zettlr window.
+
+#### Editor
+
+The "editor" in general refers to the main instance of CodeMirror launched in the main Zettlr window. It does not mean the other CodeMirror instances that are opened, e.g., in the Custom CSS dialog, or the QuickLook windows.
+
+#### QuickLook
+
+Similarly to the macOS QuickLook-feature, these are smaller (native) windows that enable you to preview a file but not edit it.
+
+#### DevTools / Development Tools
+
+The development tools are the ones you can open in Zettlr windows that enable you to debug the GUI. They work the same as the devtools shipped with Chrome-browsers and can be opened when debug-mode is enabled.
+
+#### Theme
+
+While a theme in the Zettlr context denotes the same as everywhere else, we included it here to stress the point that there is an additional CSS file loaded: `geometry.css`. The latter provides the geometric arrangement and size of elements, whereas the theme mostly only provides colouring.

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -14,7 +14,7 @@ Consultez nos guides d'utilisation afin de découvrir les différents flux de tr
 
 * [Utiliser Zettlr comme application de prise de notes](guides/guide-notes.md)
 * [Utiliser Zettlr comme Zettelkasten](guides/guide-zettelkasten.md)
-* [Utiliser Zettlr comme environnement de développement complet (IDE)](guides/guide-ide.md)
+* [Utiliser Zettlr comme environnement de développement intégré (IDE)](guides/guide-ide.md)
 
 ## Fonctionnalités de base
 

--- a/docs/fr/install.md
+++ b/docs/fr/install.md
@@ -1,99 +1,101 @@
 # Installation
 
-The installation of Zettlr is very easy and takes only a step on every operating system. Zettlr is cross-platform, so it will run on your system, no matter which one. Zettlr comes pre-built for macOS, Windows and Debian-based and RedHat-based Linux systems (Ubuntu, Gnome, Xubuntu, Kubuntu, Fedora, RedHat and the like).
+L'installation de Zettlr est très facile et ne nécessite qu'une étape sur chaque système d'exploitation. Zettlr est multiplateforme, il fonctionnera donc sur votre système, quel qu'il soit. Zettlr est pré-conçu pour les systèmes d'exploitation MacOS, Windows, ainsi que Linux basés sur Debian et RedHat (Ubuntu, Gnome, Xubuntu, Kubuntu, Fedora, RedHat et autres).
 
-If you want to run Zettlr on other Linux-Systems like Arch or on ARM-devices (such as a Raspberry), you'd have to create a package by yourself. There's plenty of easy tutorials on how to build electron apps on the web. Please refer to the [supported platforms for electron apps](https://github.com/electron/electron/blob/master/docs/tutorial/support.md) to stay up to date which platforms are supported.
+Si vous voulez faire fonctionner Zettlr sur d'autres systèmes Linux comme Arch ou bien sur des dispositifs ARM (comme un Raspberry), vous devrez créer un paquet vous-même. Il existe de nombreux tutoriels pour la création d'applications Electron sur le web. Veuillez consulter [la liste des plateformes supportées par Electron](https://github.com/electron/electron/blob/master/docs/tutorial/support.md) pour savoir lesquelles sont compatibles.
 
-> There is a community-maintained package for Arch Linux available. [You can find it on the official AUR repositories](https://aur.archlinux.org/packages/zettlr-bin/). Please note that this package is community-maintained and we do not take any responsibility in its stability, safety or offered version.
+> Il existe un paquet maintenu par la communauté pour Arch Linux. [Vous pouvez le trouver sur les dépôts officiels AUR](https://aur.archlinux.org/packages/zettlr-bin/). Veuillez noter que ce paquet est maintenu par la communauté et que nous ne sommes pas responsables quant à sa stabilité, sa sécurité ou la version proposée.
 
-## Windows (7 or newer)
+## Windows (7 ou plus récents)
 
-To install Zettlr on Windows, just download the app from the [download page](https://www.zettlr.com/download) and double click to open it. If you wish to install Zettlr for all users, it is installed to the main `Program Files`-Directory—in this case you'd have to give it elevated rights during setup (it will automatically ask for your permission). You don't need any rights if you install it for yourself.
+Pour installer Zettlr sur Windows, il suffit de télécharger l'application à partir de la [page de téléchargement](https://www.zettlr.com/download) et de double-cliquer pour l'ouvrir. Si vous souhaitez installer Zettlr pour tous les utilisateurs, il est installé dans le répertoire "Program Files" principal – dans ce cas, vous devrez lui donner les droits lors de l'installation (il vous demandera automatiquement votre autorisation). Vous n'avez pas besoin de lui donner de droits plus élevés si vous l'installez uniquement pour un utilisateur.
 
-To uninstall Zettlr, simply run the Uninstall.exe either from the directory itself or use the comfortable option in your system's settings. If you want to completely remove all data associated with the app, also remove the directory `C:\Users\<your-user-name>\AppData\Roaming\Zettlr`.
+Pour désinstaller Zettlr, il suffit d'exécuter le fichier Uninstall.exe soit à partir du répertoire lui-même, soit en utilisant l'option appropriée dans les paramètres de votre système. Si vous souhaitez supprimer complètement toutes les données associées à l'application, supprimez également le répertoire `C:\Users\<votre-nom-d-utilisateur>\AppData\Roaming\Zettlr`.
 
-## macOS (10.10 or newer)
+## macOS (10.10 ou plus récents)
 
-To install Zettlr on macOS, simply download the dmg-file from the latest release and mount it. Then drag the Zettlr-icon into your Applications directory and you're done!
+Pour installer Zettlr sur macOS, il suffit de télécharger le fichier dmg de la dernière version et de le monter. Ensuite, faites glisser l'icône Zettlr dans votre répertoire Applications et vous avez terminé !
 
-To uninstall Zettlr, simply remove the Zettlr.app from your Applications directory. If you want to completely remove all data associated with the app, also remove the directory `/Users/<your-user-name>/Library/Application Support/Zettlr`.
+Pour désinstaller Zettlr, il suffit de supprimer le fichier Zettlr.app de votre répertoire Applications. Si vous souhaitez supprimer complètement toutes les données associées à l'application, supprimez également le répertoire `/Users/<votre-nom-d-utilisateur>/Library/Application Support/Zettlr`.
 
-> You can also install Zettlr using [Homebrew](https://formulae.brew.sh/cask/zettlr): `$ brew cask install zettlr`
+> Vous pouvez également installer Zettlr en utilisant [Homebrew](https://formulae.brew.sh/cask/zettlr): `$ brew cask install zettlr`
 
-## Linux (Debian 8/Ubuntu 12.04/Fedora 21 or newer)
+## Linux (Debian 8/Ubuntu 12.04/Fedora 21 ou plus récents)
 
-There are prebuilt `deb`- and `rpm`-packages for linux systems. Simply install the package on your system.
+Il y a des paquets `deb` et `rpm` pré-construits pour les systèmes Linux. Il suffit d'installer le paquet sur votre système.
 
-To uninstall, follow the usual steps it takes to remove a package (usually through the graphical installer application or via `dpkg`). If you also want to remove all data associated with the app, also delete the `/home/<your-user-name>/.config/Zettlr` directory.
+Pour désinstaller Zettlr, suivez les étapes habituelles pour supprimer un paquet (généralement via l'interface graphique d'installation d'applications, ou via `dpkg`). Si vous souhaitez également supprimer toutes les données associées à l'application, supprimez également le répertoire `/home/<votre-nom-d-utilisateur>/.config/Zettlr`.
 
-## Updating the app
+## Mettre à jour l'application
 
 The application checks for new updates each time you start the app. You can also manually trigger the search for updates by using the respective menu item from the Help-menu. If there is a new version available, Zettlr will show you a dialog that contains both the new version's number, your current version and a changelog with all features and bug fixes the new version contains. You can then open the download page to download the new package. Simply install it over your current installation, it will take care of removing the old version first. All data will be retained and migrated to the new version.
 
-> If you are interested in cutting-edge releases, make sure to tick the checkbox "Notify me about beta releases" in the advanced tab of the preferences dialog!
+L'application vérifie les nouvelles mises à jour chaque fois que vous démarrez l'application. Vous pouvez également déclencher manuellement la recherche de mises à jour en utilisant l'option correspondante dans le menu Aide. Si une nouvelle version est disponible, Zettlr affichera un dialogue qui contient à la fois le numéro de la nouvelle version, votre version actuelle et un journal des modifications avec toutes les fonctionnalités et les corrections de bogues que la nouvelle version contient. Vous pouvez ensuite ouvrir la page de téléchargement pour télécharger le nouveau paquet. Il suffit de l'installer par-dessus votre installation actuelle, il se chargera automatiquement de supprimer l'ancienne version. Toutes les données seront conservées et migrées vers la nouvelle version.
 
-## Installing Pandoc
+> Si vous êtes intéressé par les versions les plus avancées, assurez-vous de cocher la case "M'avertir des versions bêta" dans l'onglet "Avancé" des Préférences !
 
-What makes Zettlr interact with other software such as Microsoft Word, Wiki-systems or OpenOffice is an additional software package called `Pandoc`. Pandoc is free and Open Source and it allows you to use all exporting and importing features of Zettlr, making it the ideal choice to be the interface between other programs and co-workers who do not use Markdown.
+## Installer Pandoc
 
-Installing Pandoc is easy on all platforms.
+Ce qui permet à Zettlr de coexister avec d'autres logiciels tels que Microsoft Word, LibreOffice ou même un Wiki, est un logiciel distinct appelé `Pandoc`. Pandoc est gratuit et *open source* et vous permet d'utiliser toutes les fonctionnalités d'exportation et d'importation de Zettlr, ce qui en fait le choix idéal pour servir d'interface avec d'autres programmes et de partager son travail avec des collègues qui n'utilisent pas Markdown.
 
-> You can install Pandoc at any time. Simply use the menu item from the Help menu to open up the installation instructions.
+L'installation de Pandoc est facile sur toutes les plateformes.
+
+> Vous pouvez installer Pandoc à tout moment. Il vous suffit d'utiliser l'élément correspondant du menu Aide pour ouvrir les instructions d'installation.
 
 ### Windows
 
-On Windows, Pandoc can be installed by visiting the [download page](https://github.com/jgm/pandoc/releases/latest) and retrieving the Windows installer. Simply execute it. Afterwards, it should be installed correctly. Try to export something. If it works, you're done!
+Sous Windows, Pandoc peut être installé en visitant sa [page de téléchargement](https://github.com/jgm/pandoc/releases/latest) et en récupérant le programme d'installation pour Windows. Il suffit de l'exécuter. Ensuite, il devrait être installé correctement. Essayez d'exporter quelque chose. Si cela fonctionne, vous avez terminé !
 
-> Please note that due to the fact that Pandoc is a CLI-program (Command Line Interface), it cannot show you whether or not there is an update available. You'll have to do this yourself. Simply visit the download page from time to time.
+> Pandoc est un programme exécutable en ligne de commande, il ne peut donc pas vous indiquer si une mise à jour est disponible ou non. Vous devrez le faire vous-même. Il vous suffit de visiter sa page de téléchargement de temps en temps.
 
 ### macOS
 
-On macOS, Pandoc can be installed in a variety of ways.
+Sur macOS, Pandoc peut être installé de différentes manières.
 
-#### Recommended method: Homebrew
+#### Méthode recommandée : Homebrew
 
-The preferred method is [Homebrew](https://brew.sh/). Homebrew is a package manager that makes it easy to install command line programs such as pandoc and makes it easy to maintain it. Make sure to [install Homebrew](https://brew.sh/), and then simply run the following command in the Terminal:
+La méthode recommandée est d'utiliser [Homebrew](https://brew.sh/). Homebrew est un gestionnaire de paquets qui facilite l'installation et la maintenance de programmes en ligne de commande tels que Pandoc. Assurez-vous d'installer [Homebrew](https://brew.sh/), puis exécutez simplement la commande suivante dans le Terminal :
 
 ```bash
 $ brew install pandoc
 ```
 
-To update pandoc from time to time, use this command:
+Pour mettre à jour Pandoc de temps en temps, utilisez cette commande :
 
 ```bash
 $ brew upgrade
 ```
 
-This will upgrade all installed formulae (as they are called) to the newest version.
+Cela permettra de mettre à niveau toutes les "formules" installées (ainsi que les appelle Homebrew) vers leur version la plus récente.
 
-> Installing with Homebrew is recommended, as it is not only faster, but also more convenient.
+> L'installation avec Homebrew est recommandée, car elle est non seulement plus rapide, mais aussi plus pratique.
 
-After pandoc is set up, you may want to install `citeproc` as well, as it provides you with the ability to [cite](academic/citations.md) using Zettlr. On Windows, Citeproc is automatically installed, while on macOS you will have to install Pandoc Citeproc additionally. Simply use Homebrew for this as well:
+Après la mise en place de Pandoc, vous voudrez probablement installer son filtre `citeproc`, car il vous permet de [citer](academic/citations.md) dans Zettlr. Sous Windows, Citeproc est automatiquement installé, tandis que sous macOS, vous devrez installer Citeproc en plus. Il suffit d'utiliser Homebrew pour cela aussi :
 
 ```bash
 $ brew install pandoc-citeproc
 ```
 
-#### Install using the official installer
+#### Utiliser l'installateur officiel
 
-To install Pandoc the old way, simply head over to the [download page](https://github.com/jgm/pandoc/releases/latest) and get the macOS installer. Once it is done, pandoc should be available on your system. Try to export something. If it works, you're done!
+Pour installer Pandoc à l'ancienne, il suffit de se rendre sur la [page de téléchargement](https://github.com/jgm/pandoc/releases/latest) et de télécharger l'installateur macOS. Une fois l'installation terminée, Pandoc devrait être disponible sur votre système. Essayez d'exporter quelque chose. Si cela fonctionne, vous avez terminé !
 
 ### Linux
 
-On Linux, installing Pandoc is hilariously simple. Simply use your package manager to search for, and install Pandoc. The provided packages aren't always up-to-date, but they should fit. If you want to install the newest version, you'd have to [download the Linux installer](https://github.com/jgm/pandoc/releases/latest) and follow the [install instructions](https://pandoc.org/installing.html) on the Pandoc site.
+Sous Linux, l'installation de Pandoc est d'une grande simplicité. Il suffit d'utiliser votre gestionnaire de paquets pour rechercher et installer Pandoc. Les paquets fournis ne sont pas toujours à jour, mais ils devraient convenir. Si vous souhaitez installer la dernière version, vous devez [télécharger l'installateur Linux](https://github.com/jgm/pandoc/releases/latest) et suivre les [instructions d'installation](https://pandoc.org/installing.html) sur le site de Pandoc.
 
-> You may need to set up `pandoc-citeproc` manually by installing it using the preferred method on your operating system.
+> Vous pouvez avoir besoin de configurer `pandoc-citeproc` manuellement en l'installant via la méthode préférée de votre distribution.
 
-## Installing LaTeX
+## Installer LaTeX
 
-Markdown works best if combined with `LaTeX` to create beautiful PDF files. To do so, you'd have to install a `TeX`-distribution along Zettlr. Don't worry: You won't need to learn any `LaTeX` to use it. But you'd have to install it.
+Markdown peut être combiné avec `LaTeX` pour créer de beaux fichiers PDF, avec Pandoc comme intermédiaire. Pour ce faire, vous devez installer une distribution `TeX` en même temps que Zettlr. Ne vous inquiétez pas : vous n'aurez pas besoin d'apprendre à utiliser LaTeX immédiatement. Mais son installation reste nécessaire, et ouvre la possibilité de réutiliser les nombreux modèles de documents produits par la communauté LaTeX.
 
-Installing the software works exactly the same as any other software: On Windows and macOS you'll need the installer package, while on Linux you can use your package manager to install a distribution.
+L'installation du logiciel fonctionne exactement de la même façon que n'importe quel autre logiciel : sous Windows et MacOS, vous aurez besoin d'un installateur, tandis que sous Linux, vous pourrez utiliser votre gestionnaire de paquets pour installer la distribution.
 
-The recommended distributions are:
+Les distributions recommandées sont :
 
-- Windows: [MikTeX](https://miktex.org/download)
-- macOS: [MacTex](https://www.tug.org/mactex/morepackages.html) (_Attention: It suffices to install the Basic Tex, which is much smaller than the full version!_)
-- Linux: [TeX Live](https://www.tug.org/texlive/) (install the texlive-base package: `sudo apt install texlive-base`)
+- Windows : [MikTeX](https://miktex.org/download)
+- macOS : [MacTex](https://www.tug.org/mactex/morepackages.html)
+- Linux : [TeX Live](https://www.tug.org/texlive/) (installez le paquet texlive-base : `sudo apt install texlive-base`)
 
-> You can install LaTeX at a later time. Simply use the menu item from the Help menu to open up the overview page where you can immediately see all available distributions.
+> Vous pouvez installer LaTeX ultérieurement. Utilisez simplement l'élément correspondant du menu Aide pour ouvrir une page d'aperçu où vous pouvez consulter les distributions disponibles.


### PR DESCRIPTION
Went through the config and top-level content (`5-minutes.md`, `get-involved.md`, `faq.md`, `index.md`, `install.md`). Almost all of it is in (decent) French now. I will go over the rest progressively to improve the semi-automated translation. Thanks Deepl!