### PR TITLE
change "text snippets" to "file information"

### DIFF
--- a/docs/en/core/file-list.md
+++ b/docs/en/core/file-list.md
@@ -10,9 +10,11 @@ In the extended sidebar mode, both the tree view and the file list are visible. 
 
 The file list shows you all directories and files inside the directory that is currently selected in the tree view, but not like a normal file browser: **the file list treats all subdirectories as equals, and shows you all of them one after another!** Therefore you don't need to traverse further into the directory tree to reach buried directories.
 
-If you turned off the meta information, both directories and files will be shown as one-liners. If you display the file information, you will see additional information: directories will show you the amount of children they have. The files, on the other hand, show their last modification date. If they contain an ID or tags, this information will be displayed after the modification date. Hovering over the tag counter, you can see a small tooltip that shows you all tags that are in the file.
+> Note: since version `1.3.0` the "text snippets" feature is now known as "file information"
 
-> You can toggle the file information via the "View" menu or by pressing `Cmd/Ctrl+Alt+S`.
+If you turned off the meta information, both directories and files will be shown as one-liners. If you display the *file information*, you will see additional information: directories will show you the amount of children they have. The files, on the other hand, show their last modification date. If they contain an ID or tags, this information will be displayed after the modification date. Hovering over the tag counter, you can see a small tooltip that shows you all tags that are in the file.
+
+> You can toggle the file information via the "View" menu, by pressing `Cmd/Ctrl+Alt+S`, or the relevant setting in the preferences dialog under the General section
 
 ### Meta Information on Files
 
@@ -22,7 +24,7 @@ The additional information shown by your files in the file list can be beneficia
 
 ### Writing Targets
 
-Since version `1.2`, Zettlr supports writing targets. To set a target, right-click a file and choose "Set writing target …". Enter the amount of words or characters and click "Set". Zettlr will count towards your goal and show you the progress showing a small indicator if you have snippets activated. Hover over it to see the absolute number of words or characters that you've written.
+Since version `1.2`, Zettlr supports writing targets. To set a target, right-click a file and choose "Set writing target …". Enter the amount of words or characters and click "Set". Zettlr will count towards your goal and show you the progress showing a small indicator if you have "file information" activated. Hover over it to see the absolute number of words or characters that you've written.
 
 ![Writing Targets Counter](../img/writing_targets.png)
 

--- a/docs/en/core/file-list.md
+++ b/docs/en/core/file-list.md
@@ -10,8 +10,6 @@ In the extended sidebar mode, both the tree view and the file list are visible. 
 
 The file list shows you all directories and files inside the directory that is currently selected in the tree view, but not like a normal file browser: **the file list treats all subdirectories as equals, and shows you all of them one after another!** Therefore you don't need to traverse further into the directory tree to reach buried directories.
 
-> Note: since version `1.3.0` the "text snippets" feature is now known as "file information"
-
 If you turned off the meta information, both directories and files will be shown as one-liners. If you display the *file information*, you will see additional information: directories will show you the amount of children they have. The files, on the other hand, show their last modification date. If they contain an ID or tags, this information will be displayed after the modification date. Hovering over the tag counter, you can see a small tooltip that shows you all tags that are in the file.
 
 > You can toggle the file information via the "View" menu, by pressing `Cmd/Ctrl+Alt+S`, or the relevant setting in the preferences dialog under the General section

--- a/docs/en/guides/guide-notes.md
+++ b/docs/en/guides/guide-notes.md
@@ -11,7 +11,7 @@ You want to use Zettlr as a means to take notes with. Although Zettlr has a lot 
 First, head over to the settings tab (press `Cmd/Ctrl+,` or click the cog in the toolbar). In the settings, make sure you set the settings according to this list:
 
 - General tab
-    - Snippets: Off
+    - File Information: Off
     - Sidebar: Thin
 - Editor tab
     - Dictionaries: Select none (they slow down the app start and aren't necessary for simple notes)

--- a/docs/en/guides/guide-zettelkasten.md
+++ b/docs/en/guides/guide-zettelkasten.md
@@ -13,7 +13,7 @@ Zettlr can be used as a sophisticated Zettelkasten system implementing a lot of 
 The first thing you want to do to create your Zettelkasten is to have a look at your preferences. The following settings convert Zettlr into a supercharged Zettelkasten:
 
 - General tab
-    - Turn the file information on
+    - File Information: On
     - Sidebar: Thin mode.
 - Editor tab
     - Turn off all dictionaries

--- a/docs/en/reference/shortcuts.md
+++ b/docs/en/reference/shortcuts.md
@@ -27,7 +27,7 @@ For remembering them easier, here are some thoughts we've put into assigning the
 * `Cmd/Ctrl+Shift+E`: Gives focus to the editing window.
 * `Cmd/Ctrl+Shift+T`: Gives focus to the tree window.
 * `Cmd/Ctrl+Alt+L`: Switches the theme between light and dark mode.
-* `Cmd/Ctrl+Alt+S`: Toggles display of the text snippets.
+* `Cmd/Ctrl+Alt+S`: Toggles display of file information in the File List.
 * `Cmd/Ctrl+Shift+1`: Toggles the sidebar mode to either view the file list or the tree view. Disabled in extended sidebar mode.
 * `Cmd/Ctrl+?`: Toggles display of the attachment sidebar.
 * `Cmd/Ctrl+[0-9]`: Open recent document at position 0 to 9 in the recent documents list (File->Recent Documents).


### PR DESCRIPTION
Fixes the issue I raised here https://github.com/Zettlr/zettlr-docs/issues/28

Corrected the old mentioning of "text snippets" to the new name of "file information"

