### PR TITLE
Change Linux LaTeX install to texlive-xetex

### DIFF
--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -94,6 +94,6 @@ The recommended distributions are:
 
 - Windows: [MikTeX](https://miktex.org/download)
 - macOS: [MacTex](https://www.tug.org/mactex/morepackages.html) (_Attention: It suffices to install the Basic Tex, which is much smaller than the full version!_)
-- Linux: [TeX Live](https://www.tug.org/texlive/) (install the texlive-base package: `sudo apt install texlive-base`)
+- Linux: [TeX Live](https://www.tug.org/texlive/) (install the texlive-xetex package: `sudo apt install texlive-xetex`)
 
 > You can install LaTeX at a later time. Simply use the menu item from the Help menu to open up the overview page where you can immediately see all available distributions.


### PR DESCRIPTION
As a new user on Pop_OS, I was following the LaTeX install instructions and found that Zettlr is looking for an xelatex executable, which was not in the recommended `texlive-base` package. After searching, I found the `texlive-xetex` to be the solution