### PR TITLE
Correct shortcut to display of the attachment sidebar.

### DIFF
--- a/docs/en/reference/shortcuts.md
+++ b/docs/en/reference/shortcuts.md
@@ -29,7 +29,7 @@ For remembering them easier, here are some thoughts we've put into assigning the
 * `Cmd/Ctrl+Alt+L`: Switches the theme between light and dark mode.
 * `Cmd/Ctrl+Alt+S`: Toggles display of file information in the File List.
 * `Cmd/Ctrl+Shift+1`: Toggles the sidebar mode to either view the file list or the tree view. Disabled in extended sidebar mode.
-* `Cmd/Ctrl+?`: Toggles display of the attachment sidebar.
+* `Cmd/Ctrl+Shift+?`: Toggles display of the attachment sidebar.
 * `Cmd/Ctrl+[0-9]`: Open recent document at position 0 to 9 in the recent documents list (File->Recent Documents).
 * `Cmd+Ctrl+F` (macOS) `F11` (windows/Linux): Toggle fullscreen
 * `Cmd/Ctrl+W`: Close the application window. On Windows and Linux this will also exit the app.


### PR DESCRIPTION
"Shift" was missing in the documentation.