### PR TITLE
Typo in YAML example (author)

### DIFF
--- a/docs/en/core/yaml-frontmatter.md
+++ b/docs/en/core/yaml-frontmatter.md
@@ -21,7 +21,7 @@ title: "Your document's title"
 keywords:
   - A keyword
   - Another keyword
-authors:
+author:
   - The Zettlr Team
 ```
 


### PR DESCRIPTION
The name of the variable should be `author` (as indicated below and in Pandoc documentation) and not `authors`.