### PR TITLE
Readability.md grammar edit

### DIFF
--- a/docs/en/academic/readability.md
+++ b/docs/en/academic/readability.md
@@ -4,7 +4,7 @@ Good writing encompasses many aspects. Apart from concise content, your texts ne
 
 Since the development of text, humanity's creativity has brought forth many tips to good writing. While Zettlr provides you with the perfect environment to write in, thereby making sure the _legibility_ of your text is great, the _readability_ is something you need to take care of as well. Luckily, beginning with `1.4`, Zettlr has a tool for you: The **readability mode**.
 
-> Please note that the readability score is only one out of several measurables that can help you determine the ease of reading, but should not be taken to serious. If the readability algorithm highlights a sentence in deep red, this does not necessarily mean that you should rewrite the sentence. Rather, look at the context of the sentence, which the algorithm does not take into account, to determine the quality of a sentence. **We recommend to first write your text without the mode, and then only switching it on for some passages where you have a feeling they might be difficult to understand.**
+> Please note that the readability score is only one out of several measurables that can help you determine the ease of reading, but should not be taken too serious. If the readability algorithm highlights a sentence in deep red, this does not necessarily mean that you should rewrite the sentence. Rather, look at the context of the sentence, which the algorithm does not take into account, to determine the quality of a sentence. **We recommend to first write your text without the mode, and then only switching it on for some passages where you have a feeling they might be difficult to understand.**
 
 ## What the Readability Mode does
 


### PR DESCRIPTION
I think the correct word in line 7 of readability.md is "too", because it can be replaced by "very", "excessively", etc.

See for reference:

https://grammarist.com/usage/to-too/
https://www.wikihow.com/Use-%22Too%22-and-%22To%22-Correctly
https://www.grammarly.com/blog/to-too/
https://www.thefreedictionary.com/too

(Im not sure why github says that i have changed line 45. I haven't touched it in the edit, and i also cannot see any changes in the overview. The only change that i propose is to change "to" --> "too" in line 7)