### PR TITLE
rename "shortcuts" to "keyboard shortcuts"

### DIFF
--- a/docs/en/reference/keyboard-shortcuts.md
+++ b/docs/en/reference/keyboard-shortcuts.md
@@ -1,4 +1,4 @@
-# Shortcuts
+# Keyboard Shortcuts
 
 This page contains a list of all shortcuts available throughout the app.
 


### PR DESCRIPTION
I had some trouble finding this page at first when I searched for "keyboard" - I kept finding the Tables page, and it wasn't until I manually read through the whole table of contents that I found "shortcuts" which looked promising.

This change should help other people find keyboard shortcuts more easily too :)