### PR TITLE
Updated example custom css for hiding toolbar and menubar in distraction free mode

### DIFF
--- a/docs/en/core/custom-css.md
+++ b/docs/en/core/custom-css.md
@@ -106,7 +106,7 @@ Some people prefer the distraction free mode to be _really_ distraction-free. Ze
 Simply paste the following line of CSS into the Custom CSS dialog, and from then on the toolbar will always be hidden:
 
 ```css
-body.show-menubar #editor.fullscreen, .CodeMirror-fullscreen {
+body.show-menubar #editor.fullscreen, #editpr.fullscreen, .CodeMirror-fullscreen {
   top: 0px;
 }
 ```

--- a/docs/en/core/custom-css.md
+++ b/docs/en/core/custom-css.md
@@ -106,7 +106,9 @@ Some people prefer the distraction free mode to be _really_ distraction-free. Ze
 Simply paste the following line of CSS into the Custom CSS dialog, and from then on the toolbar will always be hidden:
 
 ```css
-#editor.fullscreen, .CodeMirror-fullscreen { top: 0px; }
+body.show-menubar #editor.fullscreen, .CodeMirror-fullscreen {
+  top: 0px;
+}
 ```
 
 ### Set a maximum width for the text

--- a/docs/en/core/custom-css.md
+++ b/docs/en/core/custom-css.md
@@ -106,7 +106,7 @@ Some people prefer the distraction free mode to be _really_ distraction-free. Ze
 Simply paste the following line of CSS into the Custom CSS dialog, and from then on the toolbar will always be hidden:
 
 ```css
-body.show-menubar #editor.fullscreen, #editpr.fullscreen, .CodeMirror-fullscreen {
+body.show-menubar #editor.fullscreen, #editor.fullscreen, .CodeMirror-fullscreen {
   top: 0px;
 }
 ```


### PR DESCRIPTION
This updates the documentation to reflect changes in the codebase made for Zettlr 1.8.0. Now, on adding the following custom css to Zettlr, the menubar and toolbar should both be hidden:

```
body.show-menubar #editor.fullscreen, .CodeMirror-fullscreen {
  top: 0px;
}
```

Please see the [relevant issue](https://github.com/Zettlr/Zettlr/issues/1457) for background.