### PR TITLE
Add in `clojure` for Fenced Code Blocks

### DIFF
--- a/docs/de/reference/markdown-basics.md
+++ b/docs/de/reference/markdown-basics.md
@@ -106,6 +106,7 @@ Currently, the following languages are supported by the engine (the names in bra
 - C (`c`)
 - C# (`c#`; `csharp`; `cs`)
 - C++ ( `c++`; `cpp`)
+- Clojure ( `clojure` )
 - Common Lisp (`clisp`; `commonlisp`)
 - CSS (`css`)
 - Elm (`elm`)

--- a/docs/en/reference/markdown-basics.md
+++ b/docs/en/reference/markdown-basics.md
@@ -106,6 +106,7 @@ Currently, the following languages are supported by the engine (the names in bra
 - C (`c`)
 - C# (`c#`; `csharp`; `cs`)
 - C++ ( `c++`; `cpp`)
+- Clojure ( `clojure` )
 - Common Lisp (`clisp`; `commonlisp`)
 - CSS (`css`)
 - Elm (`elm`)

--- a/docs/fr/reference/markdown-basics.md
+++ b/docs/fr/reference/markdown-basics.md
@@ -106,6 +106,7 @@ Actuellement, les langues suivantes sont prises en charge par le moteur (les nom
 - C (`c`)
 - C# (`c#`; `csharp`; `cs`)
 - C++ ( `c++`; `cpp`)
+- Clojure ( `clojure` )
 - Common Lisp (`clisp`; `commonlisp`)
 - CSS (`css`)
 - Elm (`elm`)

--- a/docs/it/reference/markdown-basics.md
+++ b/docs/it/reference/markdown-basics.md
@@ -106,6 +106,7 @@ Al momento, sono supportati i seguenti linguaggi (tra parentesi sono riportati g
 - C (`c`)
 - C# (`c#`; `csharp`; `cs`)
 - C++ ( `c++`; `cpp`)
+- Clojure ( `clojure` )
 - Common Lisp (`clisp`; `commonlisp`)
 - CSS (`css`)
 - Elm (`elm`)

--- a/docs/ja/reference/markdown-basics.md
+++ b/docs/ja/reference/markdown-basics.md
@@ -106,6 +106,7 @@ Zettlrはいくつかのスクリプトとプログラム言語について、�
 - C (`c`)
 - C# (`c#`; `csharp`; `cs`)
 - C++ ( `c++`; `cpp`)
+- Clojure ( `clojure` )
 - Common Lisp (`clisp`; `commonlisp`)
 - CSS (`css`)
 - Elm (`elm`)


### PR DESCRIPTION
Show that Clojure is also supported for Fenced Code Blocks.

https://github.com/Zettlr/Zettlr/issues/1759

There is one other thing, in the docs, it says, quote:

```
three backticks, directly followed by the word "javascript" on an empty line.
```

That doesn't appear to be the case, I think it's more like this:

```
>  ```javascript
let x = 10
>  ```
```

i.e.,

```
three backticks, directly followed by the word "javascript".
```

Putting the syntax word, i.e., `javascript` on a new line doesn't seem to render the content correctly. 

(at least that's what happened when I tried it)

-=david=-