### PR TITLE
Make Code Fencing a bit clearer with respect to the syntax

### DIFF
--- a/docs/de/reference/markdown-basics.md
+++ b/docs/de/reference/markdown-basics.md
@@ -99,7 +99,7 @@ The second element footnotes require is a block element, the footnote _reference
 
 Zettlr also supports so-called "fenced code blocks." These are the block-version of the inline code element. To start a code block, type three backticks "\`" in a row on an empty line. Close the code block again with three back ticks on an empty line. Everything in between those two "fences" will be rendered using monospace font to indicate that this is indeed code.
 
-Zettlr supports syntax highlighting for several script and programming languages. You have to tell Zettlr explicitly which language to use by simply adding its identifier _directly after the introducing code fence_. So to direct Zettlr to highlight a code fence using a JavaScript interpreter, you would need to begin the code block with three backticks, directly followed by the word "javascript" on an empty line.
+Zettlr supports syntax highlighting for several script and programming languages. You have to tell Zettlr explicitly which language to use by simply adding its identifier _directly after the introducing code fence_. So to direct Zettlr to highlight a code fence using a JavaScript interpreter, you would need to begin the code block with three backticks, directly followed by the word "javascript".
 
 Currently, the following languages are supported by the engine (the names in braces are the identifiers you'd need to indicate the language):
 

--- a/docs/en/reference/markdown-basics.md
+++ b/docs/en/reference/markdown-basics.md
@@ -99,7 +99,7 @@ The second element footnotes require is a block element, the footnote _reference
 
 Zettlr also supports so-called "fenced code blocks." These are the block-version of the inline code element. To start a code block, type three backticks "\`" in a row on an empty line. Close the code block again with three back ticks on an empty line. Everything in between those two "fences" will be rendered using monospace font to indicate that this is indeed code.
 
-Zettlr supports syntax highlighting for several script and programming languages. You have to tell Zettlr explicitly which language to use by simply adding its identifier _directly after the introducing code fence_. So to direct Zettlr to highlight a code fence using a JavaScript interpreter, you would need to begin the code block with three backticks, directly followed by the word "javascript" on an empty line.
+Zettlr supports syntax highlighting for several script and programming languages. You have to tell Zettlr explicitly which language to use by simply adding its identifier _directly after the introducing code fence_. So to direct Zettlr to highlight a code fence using a JavaScript interpreter, you would need to begin the code block with three backticks, directly followed by the word "javascript".
 
 Currently, the following languages are supported by the engine (the names in braces are the identifiers you'd need to indicate the language):
 

--- a/docs/fr/reference/markdown-basics.md
+++ b/docs/fr/reference/markdown-basics.md
@@ -99,7 +99,7 @@ Le deuxième élément requis pour les notes de bas de page est un élément de 
 
 Zettlr soutient également ce qu'on appelle les "blocs de code clôturés". Il s'agit de la version en bloc de l'élément de code en ligne. Pour démarrer un bloc de code, tapez trois "\`" à la suite sur une ligne vide. Pour refermer le bloc de code, tapez trois backticks "\`" sur une ligne vide. Tout ce qui se trouve entre ces deux "clôtures" sera rendu en utilisant une police monospace pour indiquer qu'il s'agit bien de code.
 
-Zettlr prend en charge la coloration syntaxique pour plusieurs langages de script et de programmation. Vous devez indiquer explicitement à Zettlr quel langage utiliser en ajoutant simplement son identifiant _directement après l'introduction du code de clôture_. Ainsi, pour que Zettlr mette en évidence une clôture de code à l'aide d'un interpréteur JavaScript, il faudrait commencer le bloc de code par trois bâtons (_"backsticks"_), directement suivis du mot "javascript" sur une ligne vide.
+Zettlr prend en charge la coloration syntaxique pour plusieurs langages de script et de programmation. Vous devez indiquer explicitement à Zettlr quel langage utiliser en ajoutant simplement son identifiant _directement après l'introduction du code de clôture_. Ainsi, pour que Zettlr mette en évidence une clôture de code à l'aide d'un interpréteur JavaScript, il faudrait commencer le bloc de code par trois bâtons (_"backsticks"_), directement suivis du mot "javascript".
 
 Actuellement, les langues suivantes sont prises en charge par le moteur (les noms entre parenthèses sont les identifiants que vous devriez utiliser dans Zettlr, car ils ne contiennent pas de caractères spéciaux, ce qui pourrait perturber un moteur) :
 

--- a/docs/it/reference/markdown-basics.md
+++ b/docs/it/reference/markdown-basics.md
@@ -99,7 +99,7 @@ Il secondo elemento richiede un elemento a blocco, il _testo della nota a piè d
 
 Zettlr supporta anche i cosiddetti "blocchi di codice recintati". Questi sono delle varianti a blocco degli elementi di codice in-linea. Per iniziare un blocco di codice, digita tre "backtick" (accento grave) "\`" in una riga vuota. Chiudi il blocco di codice con altri tre backticks in una riga vuota. Tutto ciò che si troverà tra questi due "recinti" sarà reso con un carattere a spaziatura fissa per indicare che si tratta effettivamente di un codice.
 
-Zettlr supporta l'evidenziatura della sintassi per numerosi script e linguaggi di programmazione. Devi indicare esplicitamente a Zettlr quale linguaggio usare, semplicemente aggiungendo il suo identificativo _subito dopo il "recinto superiore"_. Per cui ad esempio per indicare a Zettlr di evidenziare un blocco di codice usando un interpreter di Javascript, dovrai iniziare il blocco di codice con i tre backticks in una riga vuota subito seguiti dalla parola "javascript".
+Zettlr supporta l'evidenziatura della sintassi per numerosi script e linguaggi di programmazione. Devi indicare esplicitamente a Zettlr quale linguaggio usare, semplicemente aggiungendo il suo identificativo _subito dopo il "recinto superiore"_. Per cui ad esempio per indicare a Zettlr di evidenziare un blocco di codice usando un interpreter di Javascript, dovrai iniziare il blocco di codice con i tre backticks subito seguiti dalla parola "javascript".
 
 Al momento, sono supportati i seguenti linguaggi (tra parentesi sono riportati gli identificatori da usare in Zettlr, i quali non contengono caratteri speciali che potrebbero creare problemi all'interpretazione):
 


### PR DESCRIPTION
Instead of implying that the syntax has to be on a new line after the 3
back ticks, simply say that the syntax has to follow the three back
ticks.

-=david=-