### PR TITLE
Update citations.md

### DIFF
--- a/docs/en/academic/citations.md
+++ b/docs/en/academic/citations.md
@@ -14,7 +14,7 @@ If you use Mendeley, Citavi, EndNote, or any other references management softwar
 
 ### Step 1: Install BetterBibTex
 
-The first step is to install [the BetterBibTex plugin for Zotero](https://github.com/retorquere/zotero-better-bibtex/releases/latest). Using BetterBibTex has two important benefits over not using it. First, it keeps all of your citation keys unique across your entire library. Second, it allows you to keep your exported library file up to date so you do not have to re-export it every time something changes.
+The first step is to install [the BetterBibTex plugin for Zotero](https://retorque.re/zotero-better-bibtex/installation/). Using BetterBibTex has two important benefits over not using it. First, it keeps all of your citation keys unique across your entire library. Second, it allows you to keep your exported library file up to date so you do not have to re-export it every time something changes.
 
 Each citation item has its own unique ID. This is necessary so that when you, for instance, realise that the publication date has been saved incorrectly, you can easily change it in Zotero and afterwards citeproc will use the corrected information. If you do not use BetterBibTex, it may happen that an ID is issued multiple times, which would either generate errors (the good way, because you know there's something wrong) or simply cause citeproc to use the first item that matches this ID (the bad way, because then you'd have to be lucky to spot the wrong citation after export).
 


### PR DESCRIPTION
I suggest updating the link to Better Bibtex. The current link points to the download page of the plugin .xpi file on GitHub. However, the Better Bibtex project has a user-friendly install guide that I suggest pointing to instead. This change makes sense to me because the link text in the Zettlr doc promises to help users install Better Bibtex. Linking to the Better Bibtex install guide (which, in turn, has a prominent link to the .xpi download page) is more user-friendly for folks who may be less familiar with Zotero or its plugin system.

For example, I'm about to try to have a class of undergrads use Zettlr and Zotero together. I plan to walk through the steps to connect the two in class, but many will try it beforehand based on the links they find in the syllabus. They will never have used Zotero or Zotero plugins before and will be completely mystified by the link in the Zettlr doc to a the Better Bibtex .xpi file.

If, instead, they clicked on the link in the Zettlr doc and were taken to a guide on how to install Better Bibtex and explains the nature of the .xpi file — then, I think things would be simpler for them.