### PR TITLE
Adding Flatpak instructions for Latext install

### DIFF
--- a/docs/en/installing-latex.md
+++ b/docs/en/installing-latex.md
@@ -45,3 +45,10 @@ $ sudo dnf install texlive-scheme-basic
 $ sudo dnf install texlive-scheme-medium
 $ sudo dnf install texlive-scheme-full
 ```
+
+### Flatpak
+Install the texlive plugin for Flatpak (be warned, it is the full version and thus quite large):
+
+```shell
+$ flatpak install org.freedesktop.Sdk.Extension.texlive
+```


### PR DESCRIPTION
Adding Flatpak instructions for Latex install according to [issue 3351](https://github.com/Zettlr/Zettlr/issues/3351)