### PR TITLE
Edit zkn-method.md english version

### DIFF
--- a/docs/en/advanced/zkn-method.md
+++ b/docs/en/advanced/zkn-method.md
@@ -24,7 +24,7 @@ One of the biggest problems in writing apps that try to leave files untouched wi
 
 The default ID is a good call, because it uses the date in the format YYYYMMDDHHMMSS, which is unique to the second. Also, our own experiences show that when one doesn't use easy-to-recognise IDs, one is less prone to assume stuff, making them better suited to cross-link files. Just try it yourself!
 
-Zettlr will automatically try to find an ID for a file by searching through its contents. If it has found an ID that is _not_ encapsulated by a Wiki link (more on that below), it will assume this ID internally to refer to the file. If there is more than one valid ID in the file, **the first ID will take precedence**. This way, even in long files, if you can't find the ID, simply drop a new ID on top of the file to make this assume the role of a general ID for the file.
+Zettlr will automatically try to find an ID for a file by searching through its contents. If it has found an ID that is _not_ encapsulated by a Wiki link (more on that below), it will assume this ID internally to refer to the file. If there is more than one valid ID in the file, **the first ID will take precedence**. This way, even in long files, if you can't find the ID, simply drop a new ID on top of the file to make this assume the role of a general ID for the file. If the file name has the same format as an ID, it will be used as the ID for the file and counts as the first ID.
 
 ### Internal linking
 


### PR DESCRIPTION
zkn-method.md now states that the ID can be the file name and if the filename has the format of the ID it will take precedence over any ID in the file contents.

I ran into an issue where I had been putting my IDs in my files but also my files were being created with the ID as the file name so the IDs in the file were not having an effect.

This suggested change emerged from a discussion on discord:

https://discord.com/channels/609436111860793355/874677388053717052/1336270074776129547

If this change is approved, would it be possible to find people to translate for the other versions?