### PR TITLE
Updated Markdown Shortcuts for Highlighting and Footnotes

### DIFF
--- a/docs/en/reference/keyboard-shortcuts.md
+++ b/docs/en/reference/keyboard-shortcuts.md
@@ -116,7 +116,7 @@ These shortcuts work when editing Markdown files.
 | <kbd>Cmd/Ctrl</kbd>+<kbd>K</kbd>                    | Insert link                  |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>   | Insert image                 |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>T</kbd>                    | Create task-list             |
-| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd>   | Create Footnote              |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd>     | Create Footnote              |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd>   | Toggle comment               |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>C</kbd>     | Copy with formatting         |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>V</kbd>                    | Paste with formatting        |

--- a/docs/en/reference/keyboard-shortcuts.md
+++ b/docs/en/reference/keyboard-shortcuts.md
@@ -112,9 +112,11 @@ These shortcuts work when editing Markdown files.
 |----------------------------------------------------------------|------------------------------|
 | <kbd>Cmd/Ctrl</kbd>+<kbd>B</kbd>                    | Bold                         |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>I</kbd>                    | Italic                       |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>H</kbd>   | Highlight Text               |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>K</kbd>                    | Insert link                  |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>   | Insert image                 |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>T</kbd>                    | Create task-list             |
+| <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd>   | Create Footnote              |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd>   | Toggle comment               |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>C</kbd>     | Copy with formatting         |
 | <kbd>Cmd/Ctrl</kbd>+<kbd>V</kbd>                    | Paste with formatting        |


### PR DESCRIPTION
Added shortcuts for highlighting text and adding footnotes, it wasn't written on the docs page but I noticed it was already implemented into the zettlr source code + works on the current version of Zettlr.